### PR TITLE
#17: Add JSONL capture replay and offline TUI slice

### DIFF
--- a/src/bin/obdentic-capture-replay.rs
+++ b/src/bin/obdentic-capture-replay.rs
@@ -1,0 +1,70 @@
+pub use obdentic::{capture_events, jsonl_capture, prepare_read, telemetry, Transaction};
+
+#[path = "../capture_replay.rs"]
+mod capture_replay;
+
+use capture_replay::CaptureReplay;
+use obdentic::tui;
+use std::{env, path::Path};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let (capture_path, layout_path) = match args.as_slice() {
+        [capture] => (capture.as_str(), None),
+        [capture, flag, layout] if flag == "--layout" => (capture.as_str(), Some(layout.as_str())),
+        _ => {
+            return Err(
+                "usage: obdentic-capture-replay <capture.jsonl> [--layout <layout.tsv>]".into(),
+            )
+        }
+    };
+
+    let capture = jsonl_capture::read(Path::new(capture_path))?;
+    let replay = CaptureReplay::from_capture(&capture);
+    if replay.transactions().is_empty() {
+        let detail = replay
+            .issues()
+            .first()
+            .map(|issue| format!("; first replay issue: {}", issue.detail()))
+            .unwrap_or_default();
+        return Err(format!(
+            "capture contains no replayable semantic reads{detail}"
+        ));
+    }
+
+    let capacity = replay.transactions().len().max(1);
+    let telemetry = replay.telemetry_full(capacity)?;
+    let layout = layout_path.map_or_else(
+        || Ok(tui::engine_overview()),
+        |path| tui::load_layout(Path::new(path)),
+    )?;
+
+    tui::run(&layout, &telemetry, replay.transactions())?;
+    println!(
+        "capture replay  reads={} timed_reads={} issues={} duration={:.3}s",
+        replay.transactions().len(),
+        replay.offsets_us().len(),
+        replay.issues().len(),
+        replay.duration_us() as f64 / 1_000_000.0
+    );
+    for issue in replay.issues().iter().take(10) {
+        println!(
+            "replay issue  {:.3}s {:?} {} {}",
+            issue.at_us() as f64 / 1_000_000.0,
+            issue.kind(),
+            issue.semantic(),
+            issue.detail()
+        );
+    }
+    if replay.issues().len() > 10 {
+        println!("replay issue  ... {} more", replay.issues().len() - 10);
+    }
+    Ok(())
+}

--- a/src/bin/obdentic-capture-replay.rs
+++ b/src/bin/obdentic-capture-replay.rs
@@ -1,10 +1,4 @@
-pub use obdentic::{capture_events, jsonl_capture, prepare_read, telemetry, Transaction};
-
-#[path = "../capture_replay.rs"]
-mod capture_replay;
-
-use capture_replay::CaptureReplay;
-use obdentic::tui;
+use obdentic::{capture_replay::CaptureReplay, jsonl_capture, tui};
 use std::{env, path::Path};
 
 fn main() {
@@ -48,15 +42,16 @@ fn run() -> Result<(), String> {
 
     tui::run(&layout, &telemetry, replay.transactions())?;
     println!(
-        "capture replay  reads={} timed_reads={} issues={} duration={:.3}s",
+        "capture replay  reads={} issues={} duration={:.6}s first_us={} last_us={}",
         replay.transactions().len(),
-        replay.offsets_us().len(),
         replay.issues().len(),
-        replay.duration_us() as f64 / 1_000_000.0
+        replay.duration_us() as f64 / 1_000_000.0,
+        replay.offsets_us().first().copied().unwrap_or(0),
+        replay.offsets_us().last().copied().unwrap_or(0),
     );
     for issue in replay.issues().iter().take(10) {
         println!(
-            "replay issue  {:.3}s {:?} {} {}",
+            "replay issue  {:.6}s {:?} {} {}",
             issue.at_us() as f64 / 1_000_000.0,
             issue.kind(),
             issue.semantic(),

--- a/src/bin/obdentic-capture-tui.rs
+++ b/src/bin/obdentic-capture-tui.rs
@@ -1,0 +1,1 @@
+include!("obdentic_capture_tui_v2.in");

--- a/src/bin/obdentic_capture_tui_v2.in
+++ b/src/bin/obdentic_capture_tui_v2.in
@@ -1,0 +1,1272 @@
+use obdentic::{
+    capture_events::{CaptureEvent, CaptureValue, SubscriptionFilterOutcome},
+    hex,
+    jsonl_capture::{self, CaptureStatus, ParsedCapture},
+    tui::{self, DashboardLayout, Panel, View},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    crossterm::{
+        event::{self, Event, KeyCode},
+        execute,
+        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    },
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Style},
+    text::Line,
+    widgets::{Axis, Block, Borders, Chart, Dataset, GraphType, List, ListItem, Paragraph},
+    Frame, Terminal,
+};
+use std::{collections::BTreeMap, env, io, path::Path};
+
+#[cfg(test)]
+use ratatui::backend::TestBackend;
+
+const DEFAULT_WINDOW_US: u64 = 60_000_000;
+const MIN_WINDOW_US: u64 = 1_000_000;
+const STALE_AFTER_INTERVALS: u64 = 2;
+const FEED_ROWS: usize = 6;
+
+#[derive(Clone, Debug, PartialEq)]
+struct Sample {
+    at_us: u64,
+    value: CaptureValue,
+    unit: String,
+    source: String,
+    profile: String,
+    decoder: String,
+    provenance: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Evidence {
+    at_us: u64,
+    kind: &'static str,
+    semantic: Option<String>,
+    text: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Availability {
+    Captured,
+    Unsupported,
+    RequestedNoSample,
+    NotCaptured,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct Timeline {
+    status: CaptureStatus,
+    profile: Option<String>,
+    duration_us: u64,
+    samples: BTreeMap<String, Vec<Sample>>,
+    subscriptions: BTreeMap<String, SubscriptionFilterOutcome>,
+    requested_intervals_us: BTreeMap<String, u64>,
+    evidence: Vec<Evidence>,
+}
+
+impl Timeline {
+    fn from_capture(capture: &ParsedCapture) -> Self {
+        let mut timeline = Self {
+            status: capture.status,
+            profile: None,
+            duration_us: 0,
+            samples: BTreeMap::new(),
+            subscriptions: BTreeMap::new(),
+            requested_intervals_us: BTreeMap::new(),
+            evidence: Vec::new(),
+        };
+        let mut clock_us = 0_u64;
+        let mut pending_responses = Vec::new();
+
+        for event in &capture.events {
+            match event {
+                CaptureEvent::CaptureStarted { profile, .. } => {
+                    timeline.profile = profile.clone();
+                    timeline.push(
+                        0,
+                        "capture",
+                        None,
+                        format!("started profile={}", profile.as_deref().unwrap_or("unknown")),
+                    );
+                }
+                CaptureEvent::SessionInitialized => {
+                    timeline.push(clock_us, "session", None, "initialized".into());
+                }
+                CaptureEvent::SubscriptionConfigured {
+                    semantic,
+                    requested_interval_us,
+                    filter,
+                } => {
+                    timeline.subscriptions.insert(semantic.clone(), *filter);
+                    timeline
+                        .requested_intervals_us
+                        .insert(semantic.clone(), *requested_interval_us);
+                    timeline.push(
+                        clock_us,
+                        "subscription",
+                        Some(semantic.clone()),
+                        format!("{}ms {}", requested_interval_us / 1_000, filter_text(*filter)),
+                    );
+                }
+                CaptureEvent::SupportDiscovery {
+                    request_payload,
+                    responder,
+                    response_payload,
+                } => timeline.push(
+                    clock_us,
+                    "support",
+                    None,
+                    format!(
+                        "{} TX {} RX {}",
+                        responder.as_deref().unwrap_or("unknown"),
+                        hex(request_payload),
+                        hex(response_payload)
+                    ),
+                ),
+                CaptureEvent::ProtocolNegotiationObserved {
+                    request_payload,
+                    responder,
+                    response_payload,
+                } => timeline.push(
+                    clock_us,
+                    "protocol",
+                    None,
+                    format!(
+                        "{} TX {} RX {}",
+                        responder.as_deref().unwrap_or("unknown"),
+                        hex(request_payload),
+                        hex(response_payload)
+                    ),
+                ),
+                CaptureEvent::ResponsesObserved {
+                    semantic,
+                    request_payload,
+                    responses,
+                    selected_responder,
+                    selection_error,
+                } => {
+                    let responders = responses
+                        .iter()
+                        .map(|response| {
+                            format!(
+                                "{}:{}",
+                                response.responder.as_deref().unwrap_or("unknown"),
+                                hex(&response.payload)
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" | ");
+                    timeline.push(
+                        clock_us,
+                        "responses",
+                        Some(semantic.clone()),
+                        format!(
+                            "TX {} [{}] selected={}{}",
+                            hex(request_payload),
+                            responders,
+                            selected_responder.as_deref().unwrap_or("none"),
+                            selection_error
+                                .as_ref()
+                                .map(|error| format!(" error={error}"))
+                                .unwrap_or_default()
+                        ),
+                    );
+                    pending_responses.push(timeline.evidence.len() - 1);
+                }
+                CaptureEvent::ReadSucceeded {
+                    semantic,
+                    finished_us,
+                    request_payload,
+                    response_payload,
+                    value,
+                    unit,
+                    source,
+                    profile,
+                    decoder,
+                    provenance,
+                    ..
+                } => {
+                    clock_us = clock_us.max(*finished_us);
+                    timeline.duration_us = timeline.duration_us.max(*finished_us);
+                    for index in pending_responses.drain(..) {
+                        timeline.evidence[index].at_us = *finished_us;
+                    }
+                    timeline
+                        .samples
+                        .entry(semantic.clone())
+                        .or_default()
+                        .push(Sample {
+                            at_us: *finished_us,
+                            value: value.clone(),
+                            unit: unit.clone(),
+                            source: source.clone(),
+                            profile: profile.clone(),
+                            decoder: decoder.clone(),
+                            provenance: provenance.clone(),
+                        });
+                    timeline.push(
+                        *finished_us,
+                        "read_ok",
+                        Some(semantic.clone()),
+                        format!(
+                            "TX {} RX {} -> {} {}",
+                            hex(request_payload),
+                            hex(response_payload),
+                            value_text(value),
+                            unit
+                        ),
+                    );
+                }
+                CaptureEvent::ReadFailed {
+                    semantic,
+                    timing,
+                    request_payload,
+                    error,
+                    ..
+                } => {
+                    let at_us = timing.map(|timing| timing.finished_us).unwrap_or(clock_us);
+                    clock_us = clock_us.max(at_us);
+                    timeline.duration_us = timeline.duration_us.max(at_us);
+                    for index in pending_responses.drain(..) {
+                        timeline.evidence[index].at_us = at_us;
+                    }
+                    timeline.push(
+                        at_us,
+                        "read_error",
+                        Some(semantic.clone()),
+                        format!(
+                            "TX {} error={error}",
+                            request_payload
+                                .as_deref()
+                                .map(hex)
+                                .unwrap_or_else(|| "none".into())
+                        ),
+                    );
+                }
+                CaptureEvent::SlotsSkipped {
+                    semantic,
+                    count,
+                    last_due_us,
+                    ..
+                } => {
+                    clock_us = clock_us.max(*last_due_us);
+                    timeline.duration_us = timeline.duration_us.max(*last_due_us);
+                    timeline.push(
+                        *last_due_us,
+                        "skipped",
+                        Some(semantic.clone()),
+                        format!("slots={count}"),
+                    );
+                }
+                CaptureEvent::SessionError { error } => {
+                    timeline.push(clock_us, "session_error", None, error.clone());
+                }
+                CaptureEvent::RuntimeStateChanged {
+                    from, to, event, ..
+                } => timeline.push(
+                    clock_us,
+                    "runtime",
+                    None,
+                    format!("{} -> {} ({event:?})", from.serialize(), to.serialize()),
+                ),
+                CaptureEvent::ShutdownRequested => {
+                    timeline.push(clock_us, "shutdown", None, "requested".into());
+                }
+                CaptureEvent::SessionStopped { offset_us } => {
+                    timeline.duration_us = timeline.duration_us.max(*offset_us);
+                    timeline.push(*offset_us, "session", None, "stopped".into());
+                }
+                CaptureEvent::DiagnosticJobStarted { job_id, .. } => {
+                    timeline.push(clock_us, "job", None, format!("{job_id} started"));
+                }
+                CaptureEvent::DiagnosticJobStep {
+                    job_id,
+                    step_sequence,
+                    status,
+                    error,
+                    ..
+                } => timeline.push(
+                    clock_us,
+                    "job_step",
+                    None,
+                    format!(
+                        "{job_id} step={step_sequence} {}{}",
+                        status.as_str(),
+                        error
+                            .as_ref()
+                            .map(|error| format!(" error={error}"))
+                            .unwrap_or_default()
+                    ),
+                ),
+                CaptureEvent::DiagnosticJobCompleted { job_id, status } => {
+                    timeline.push(clock_us, "job", None, format!("{job_id} {status:?}"));
+                }
+                CaptureEvent::DiagnosticJobFailed { job_id, error } => {
+                    timeline.push(clock_us, "job_error", None, format!("{job_id} {error}"));
+                }
+                CaptureEvent::DiagnosticJobCancelled { job_id } => {
+                    timeline.push(clock_us, "job", None, format!("{job_id} cancelled"));
+                }
+                CaptureEvent::DtcTransportObserved {
+                    job_id,
+                    responder,
+                    outcome,
+                    ..
+                } => timeline.push(
+                    clock_us,
+                    "dtc_transport",
+                    None,
+                    format!(
+                        "{job_id} {} {outcome:?}",
+                        responder.as_deref().unwrap_or("unknown")
+                    ),
+                ),
+                CaptureEvent::DtcObservation {
+                    job_id,
+                    responder,
+                    fact,
+                    ..
+                } => timeline.push(
+                    clock_us,
+                    "dtc_fact",
+                    None,
+                    format!(
+                        "{job_id} {} {fact:?}",
+                        responder.as_deref().unwrap_or("unknown")
+                    ),
+                ),
+            }
+        }
+
+        for samples in timeline.samples.values_mut() {
+            samples.sort_by_key(|sample| sample.at_us);
+        }
+        timeline.evidence.sort_by_key(|event| event.at_us);
+        timeline
+    }
+
+    fn push(&mut self, at_us: u64, kind: &'static str, semantic: Option<String>, text: String) {
+        self.evidence.push(Evidence {
+            at_us,
+            kind,
+            semantic,
+            text,
+        });
+    }
+
+    fn availability(&self, semantic: &str) -> Availability {
+        if self
+            .samples
+            .get(semantic)
+            .is_some_and(|samples| !samples.is_empty())
+        {
+            return Availability::Captured;
+        }
+        match self.subscriptions.get(semantic) {
+            Some(SubscriptionFilterOutcome::Scheduled) => Availability::RequestedNoSample,
+            Some(SubscriptionFilterOutcome::Unsupported | SubscriptionFilterOutcome::Unknown) => {
+                Availability::Unsupported
+            }
+            None => Availability::NotCaptured,
+        }
+    }
+
+    fn current_at(&self, semantic: &str, cursor_us: u64) -> Option<&Sample> {
+        let samples = self.samples.get(semantic)?;
+        let index = samples.partition_point(|sample| sample.at_us <= cursor_us);
+        index.checked_sub(1).and_then(|index| samples.get(index))
+    }
+
+    fn samples_in(&self, semantic: &str, start_us: u64, end_us: u64) -> &[Sample] {
+        let Some(samples) = self.samples.get(semantic) else {
+            return &[];
+        };
+        let start = samples.partition_point(|sample| sample.at_us < start_us);
+        let end = samples.partition_point(|sample| sample.at_us <= end_us);
+        &samples[start..end]
+    }
+
+    fn evidence_in(&self, start_us: u64, end_us: u64) -> &[Evidence] {
+        let start = self.evidence.partition_point(|event| event.at_us < start_us);
+        let end = self.evidence.partition_point(|event| event.at_us <= end_us);
+        &self.evidence[start..end]
+    }
+
+    fn stale_after_us(&self, semantic: &str) -> Option<u64> {
+        self.requested_intervals_us
+            .get(semantic)
+            .copied()
+            .map(|interval| interval.saturating_mul(STALE_AFTER_INTERVALS))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Nav {
+    cursor_us: u64,
+    window_us: u64,
+}
+
+impl Nav {
+    fn new(duration_us: u64) -> Self {
+        Self {
+            cursor_us: duration_us,
+            window_us: DEFAULT_WINDOW_US.min(duration_us.max(MIN_WINDOW_US)),
+        }
+    }
+
+    fn bounds(self, duration_us: u64) -> (u64, u64) {
+        if duration_us <= self.window_us {
+            return (0, duration_us.max(1));
+        }
+        let half = self.window_us / 2;
+        let mut start = self.cursor_us.saturating_sub(half);
+        let mut end = start.saturating_add(self.window_us);
+        if end > duration_us {
+            end = duration_us;
+            start = end.saturating_sub(self.window_us);
+        }
+        (start, end.max(start + 1))
+    }
+
+    fn key(&mut self, key: KeyCode, duration_us: u64) {
+        let step = (self.window_us / 10).max(100_000);
+        match key {
+            KeyCode::Left => self.cursor_us = self.cursor_us.saturating_sub(step),
+            KeyCode::Right => {
+                self.cursor_us = self.cursor_us.saturating_add(step).min(duration_us);
+            }
+            KeyCode::PageUp => self.cursor_us = self.cursor_us.saturating_sub(self.window_us),
+            KeyCode::PageDown => {
+                self.cursor_us = self.cursor_us.saturating_add(self.window_us).min(duration_us);
+            }
+            KeyCode::Home | KeyCode::Char('g') => self.cursor_us = 0,
+            KeyCode::End | KeyCode::Char('G') => self.cursor_us = duration_us,
+            KeyCode::Char('+') | KeyCode::Char('=') => {
+                self.window_us = (self.window_us / 2)
+                    .max(MIN_WINDOW_US)
+                    .min(duration_us.max(MIN_WINDOW_US));
+            }
+            KeyCode::Char('-') => {
+                self.window_us = self
+                    .window_us
+                    .saturating_mul(2)
+                    .min(duration_us.max(MIN_WINDOW_US));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn filter_text(filter: SubscriptionFilterOutcome) -> &'static str {
+    match filter {
+        SubscriptionFilterOutcome::Scheduled => "scheduled",
+        SubscriptionFilterOutcome::Unsupported => "unsupported",
+        SubscriptionFilterOutcome::Unknown => "unknown",
+    }
+}
+
+fn value_text(value: &CaptureValue) -> String {
+    match value {
+        CaptureValue::Number(value) => format!("{value:.3}"),
+        CaptureValue::Boolean(value) => value.to_string(),
+        CaptureValue::Enum(value) | CaptureValue::Text(value) => value.clone(),
+        CaptureValue::Unavailable { reason } => format!("unavailable({reason})"),
+    }
+}
+
+fn numeric(samples: &[Sample]) -> Vec<(f64, f64)> {
+    samples
+        .iter()
+        .filter_map(|sample| match &sample.value {
+            CaptureValue::Number(value) => Some((sample.at_us as f64 / 1_000_000.0, *value)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn numeric_segments(samples: &[Sample], max_gap_us: Option<u64>) -> Vec<Vec<(f64, f64)>> {
+    let mut segments = Vec::<Vec<(f64, f64)>>::new();
+    let mut previous_at_us = None;
+    for sample in samples {
+        let CaptureValue::Number(value) = &sample.value else {
+            continue;
+        };
+        let split = previous_at_us
+            .zip(max_gap_us)
+            .is_some_and(|(previous, max_gap)| sample.at_us.saturating_sub(previous) > max_gap);
+        if segments.is_empty() || split {
+            segments.push(Vec::new());
+        }
+        segments
+            .last_mut()
+            .expect("a segment exists")
+            .push((sample.at_us as f64 / 1_000_000.0, *value));
+        previous_at_us = Some(sample.at_us);
+    }
+    segments
+}
+
+fn bounds(left: &[(f64, f64)], right: &[(f64, f64)]) -> (f64, f64) {
+    let mut values = left.iter().chain(right.iter()).map(|(_, y)| *y);
+    let Some(first) = values.next() else {
+        return (0.0, 1.0);
+    };
+    let (mut min, mut max) = (first, first);
+    for value in values {
+        min = min.min(value);
+        max = max.max(value);
+    }
+    if min == max {
+        max += 1.0;
+    }
+    (min, max)
+}
+
+fn unavailable(
+    frame: &mut Frame,
+    area: Rect,
+    panel: &Panel,
+    timeline: &Timeline,
+    semantic: &str,
+) {
+    let status = match timeline.availability(semantic) {
+        Availability::Captured => "no sample in window",
+        Availability::Unsupported => "unsupported / unavailable",
+        Availability::RequestedNoSample => "requested but not sampled",
+        Availability::NotCaptured => "not captured",
+    };
+    frame.render_widget(
+        Paragraph::new(format!("{status}: {semantic}"))
+            .block(Block::default().borders(Borders::ALL).title(panel.title.as_str())),
+        area,
+    );
+}
+
+fn panel(
+    frame: &mut Frame,
+    area: Rect,
+    panel: &Panel,
+    timeline: &Timeline,
+    nav: Nav,
+    start_us: u64,
+    end_us: u64,
+) {
+    match panel.view {
+        View::Value => {
+            let [semantic] = panel.signals.as_slice() else {
+                return unavailable(frame, area, panel, timeline, "invalid value panel");
+            };
+            let Some(sample) = timeline.current_at(semantic, nav.cursor_us) else {
+                return unavailable(frame, area, panel, timeline, semantic);
+            };
+            let age_us = nav.cursor_us.saturating_sub(sample.at_us);
+            let freshness = timeline.stale_after_us(semantic).map(|stale_after_us| {
+                if age_us > stale_after_us {
+                    (
+                        format!(
+                            "STALE age={}ms threshold={}ms source={}",
+                            age_us / 1_000,
+                            stale_after_us / 1_000,
+                            sample.source
+                        ),
+                        Color::Yellow,
+                    )
+                } else {
+                    (
+                        format!("fresh age={}ms source={}", age_us / 1_000, sample.source),
+                        Color::Green,
+                    )
+                }
+            });
+            let freshness = freshness.unwrap_or_else(|| {
+                (
+                    format!("age={}ms source={}", age_us / 1_000, sample.source),
+                    Color::Reset,
+                )
+            });
+            frame.render_widget(
+                Paragraph::new(vec![
+                    Line::from(format!("{} {}", value_text(&sample.value), sample.unit))
+                        .style(Style::default().fg(Color::Cyan)),
+                    Line::from(format!("{semantic} {}", freshness.0))
+                        .style(Style::default().fg(freshness.1)),
+                    Line::from(format!("profile={} decoder={}", sample.profile, sample.decoder)),
+                    Line::from(format!("provenance={}", sample.provenance)),
+                ])
+                .block(Block::default().borders(Borders::ALL).title(panel.title.as_str())),
+                area,
+            );
+        }
+        View::Sparkline => {
+            let [semantic] = panel.signals.as_slice() else {
+                return unavailable(frame, area, panel, timeline, "invalid sparkline panel");
+            };
+            let samples = timeline.samples_in(semantic, start_us, end_us);
+            let points = numeric(samples);
+            if points.is_empty() {
+                return unavailable(frame, area, panel, timeline, semantic);
+            }
+            let max_gap_us = timeline
+                .requested_intervals_us
+                .get(semantic)
+                .copied()
+                .map(|interval| interval.saturating_mul(STALE_AFTER_INTERVALS));
+            let segments = numeric_segments(samples, max_gap_us);
+            let (y_min, y_max) = bounds(&points, &[]);
+            let mut datasets = vec![Dataset::default()
+                .graph_type(GraphType::Scatter)
+                .data(&points)];
+            datasets.extend(
+                segments
+                    .iter()
+                    .filter(|segment| segment.len() > 1)
+                    .map(|segment| Dataset::default().graph_type(GraphType::Line).data(segment)),
+            );
+            frame.render_widget(
+                Chart::new(datasets)
+                    .block(Block::default().borders(Borders::ALL).title(panel.title.as_str()))
+                    .x_axis(Axis::default().bounds([
+                        start_us as f64 / 1_000_000.0,
+                        end_us as f64 / 1_000_000.0,
+                    ]))
+                    .y_axis(Axis::default().bounds([y_min, y_max])),
+                area,
+            );
+        }
+        View::TimeSeries => {
+            let [semantic] = panel.signals.as_slice() else {
+                return unavailable(frame, area, panel, timeline, "invalid timeseries panel");
+            };
+            let samples = timeline.samples_in(semantic, start_us, end_us);
+            let points = numeric(samples);
+            if points.is_empty() {
+                return unavailable(frame, area, panel, timeline, semantic);
+            }
+            let unit = samples
+                .iter()
+                .find_map(|sample| {
+                    matches!(&sample.value, CaptureValue::Number(_)).then_some(sample.unit.as_str())
+                })
+                .unwrap_or("");
+            let (y_min, y_max) = bounds(&points, &[]);
+            let chart = Chart::new(vec![Dataset::default()
+                .name(semantic.as_str())
+                .graph_type(GraphType::Line)
+                .data(&points)])
+            .block(Block::default().borders(Borders::ALL).title(panel.title.as_str()))
+            .x_axis(
+                Axis::default()
+                    .title("capture seconds")
+                    .bounds([
+                        start_us as f64 / 1_000_000.0,
+                        end_us as f64 / 1_000_000.0,
+                    ]),
+            )
+            .y_axis(Axis::default().title(unit).bounds([y_min, y_max]));
+            frame.render_widget(chart, area);
+        }
+        View::Compare => {
+            let [left, right] = panel.signals.as_slice() else {
+                return unavailable(frame, area, panel, timeline, "invalid compare panel");
+            };
+            let left_samples = timeline.samples_in(left, start_us, end_us);
+            let right_samples = timeline.samples_in(right, start_us, end_us);
+            let left_points = numeric(left_samples);
+            let right_points = numeric(right_samples);
+            if left_points.is_empty() || right_points.is_empty() {
+                return unavailable(
+                    frame,
+                    area,
+                    panel,
+                    timeline,
+                    &format!("{left}/{right}"),
+                );
+            }
+            let left_unit = left_samples
+                .iter()
+                .find_map(|sample| {
+                    matches!(&sample.value, CaptureValue::Number(_)).then_some(sample.unit.as_str())
+                })
+                .unwrap_or("");
+            let right_unit = right_samples
+                .iter()
+                .find_map(|sample| {
+                    matches!(&sample.value, CaptureValue::Number(_)).then_some(sample.unit.as_str())
+                })
+                .unwrap_or("");
+            if left_unit != right_unit {
+                frame.render_widget(
+                    Paragraph::new(format!("incompatible units: {left_unit} vs {right_unit}"))
+                        .block(Block::default().borders(Borders::ALL).title(panel.title.as_str())),
+                    area,
+                );
+                return;
+            }
+            let (y_min, y_max) = bounds(&left_points, &right_points);
+            let chart = Chart::new(vec![
+                Dataset::default()
+                    .name(left.as_str())
+                    .graph_type(GraphType::Line)
+                    .data(&left_points),
+                Dataset::default()
+                    .name(right.as_str())
+                    .graph_type(GraphType::Line)
+                    .data(&right_points),
+            ])
+            .block(Block::default().borders(Borders::ALL).title(panel.title.as_str()))
+            .x_axis(
+                Axis::default()
+                    .title("capture seconds")
+                    .bounds([
+                        start_us as f64 / 1_000_000.0,
+                        end_us as f64 / 1_000_000.0,
+                    ]),
+            )
+            .y_axis(Axis::default().title(left_unit).bounds([y_min, y_max]));
+            frame.render_widget(chart, area);
+        }
+    }
+}
+
+fn offline_engine_overview() -> DashboardLayout {
+    let mut layout = tui::engine_overview();
+    if let Some(compare) = layout
+        .panels
+        .iter_mut()
+        .find(|panel| panel.view == View::Compare)
+    {
+        compare.title = "MAP / barometric pressure".into();
+        compare.signals = vec![
+            "engine.intake_manifold_pressure".into(),
+            "engine.barometric_pressure".into(),
+        ];
+    }
+    layout
+}
+
+fn is_evidence_feed_event(event: &Evidence) -> bool {
+    matches!(
+        event.kind,
+        "capture"
+            | "session"
+            | "shutdown"
+            | "read_ok"
+            | "read_error"
+            | "responses"
+            | "support"
+            | "protocol"
+            | "job"
+            | "job_step"
+            | "job_error"
+            | "dtc_fact"
+            | "dtc_transport"
+    )
+}
+
+fn is_problem_event(event: &Evidence) -> bool {
+    matches!(event.kind, "read_error" | "skipped" | "session_error" | "job_error")
+}
+
+fn problem_style(kind: &str) -> Style {
+    match kind {
+        "skipped" => Style::default().fg(Color::Yellow),
+        "read_error" | "session_error" | "job_error" => Style::default().fg(Color::Red),
+        _ => Style::default(),
+    }
+}
+
+fn render(frame: &mut Frame, layout: &DashboardLayout, timeline: &Timeline, nav: Nav, path: &str) {
+    let areas = Layout::vertical([
+        Constraint::Length(4),
+        Constraint::Min(12),
+        Constraint::Length(9),
+    ])
+    .split(frame.area());
+    let (start_us, end_us) = nav.bounds(timeline.duration_us);
+    let evidence_end_us = nav.cursor_us.min(end_us);
+    let status = if timeline.status == CaptureStatus::Complete {
+        "COMPLETE"
+    } else {
+        "PARTIAL"
+    };
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(format!(
+                "OBDentic | {path} | {status} | profile={}",
+                timeline.profile.as_deref().unwrap_or("unknown")
+            )),
+            Line::from(format!(
+                "cursor {:.3}s/{:.3}s window {:.3}s..{:.3}s | arrows PgUp/PgDn Home/End +/- q/Esc",
+                nav.cursor_us as f64 / 1_000_000.0,
+                timeline.duration_us as f64 / 1_000_000.0,
+                start_us as f64 / 1_000_000.0,
+                end_us as f64 / 1_000_000.0
+            )),
+        ])
+        .block(Block::default().borders(Borders::ALL).title("Offline capture")),
+        areas[0],
+    );
+
+    let rows = layout.panels.len().div_ceil(2);
+    if rows > 0 {
+        let row_areas =
+            Layout::vertical(vec![Constraint::Ratio(1, rows as u32); rows]).split(areas[1]);
+        for (panel_def, area) in layout.panels.iter().zip(row_areas.iter().flat_map(|row| {
+            let columns = Layout::horizontal([
+                Constraint::Percentage(50),
+                Constraint::Percentage(50),
+            ])
+            .split(*row);
+            [columns[0], columns[1]]
+        })) {
+            panel(frame, area, panel_def, timeline, nav, start_us, end_us);
+        }
+    }
+
+    let bottom = Layout::horizontal([Constraint::Percentage(68), Constraint::Percentage(32)])
+        .split(areas[2]);
+    let visible = timeline.evidence_in(start_us, evidence_end_us);
+
+    let relevant = visible
+        .iter()
+        .filter(|event| is_evidence_feed_event(event))
+        .collect::<Vec<_>>();
+    let evidence = relevant.iter().rev().take(FEED_ROWS).collect::<Vec<_>>();
+    frame.render_widget(
+        List::new(evidence.into_iter().rev().map(|event| {
+            ListItem::new(format!(
+                "{:>7.3}s {} {} {}",
+                event.at_us as f64 / 1_000_000.0,
+                event.kind,
+                event.semantic.as_deref().unwrap_or(""),
+                event.text
+            ))
+        }))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!("Evidence / TX / RX ({})", relevant.len())),
+        ),
+        bottom[0],
+    );
+
+    let problems = visible
+        .iter()
+        .filter(|event| is_problem_event(event))
+        .collect::<Vec<_>>();
+    let problem_rows = problems.iter().rev().take(FEED_ROWS).collect::<Vec<_>>();
+    if problem_rows.is_empty() {
+        frame.render_widget(
+            Paragraph::new("no problems <= cursor in visible window")
+                .style(Style::default().fg(Color::Green))
+                .block(Block::default().borders(Borders::ALL).title("Problems (0)")),
+            bottom[1],
+        );
+    } else {
+        frame.render_widget(
+            List::new(problem_rows.into_iter().rev().map(|event| {
+                ListItem::new(format!(
+                    "{:>7.2}s {} {} {}",
+                    event.at_us as f64 / 1_000_000.0,
+                    event.kind,
+                    event.semantic.as_deref().unwrap_or(""),
+                    event.text
+                ))
+                .style(problem_style(event.kind))
+            }))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!("Problems ({})", problems.len())),
+            ),
+            bottom[1],
+        );
+    }
+}
+
+fn run_tui(path: &Path, layout: &DashboardLayout) -> Result<(), String> {
+    let capture = jsonl_capture::read(path)?;
+    let timeline = Timeline::from_capture(&capture);
+    enable_raw_mode().map_err(|error| error.to_string())?;
+    let mut stdout = io::stdout();
+    if let Err(error) = execute!(stdout, EnterAlternateScreen) {
+        let _ = disable_raw_mode();
+        return Err(error.to_string());
+    }
+    let mut terminal =
+        Terminal::new(CrosstermBackend::new(stdout)).map_err(|error| error.to_string())?;
+    let mut nav = Nav::new(timeline.duration_us);
+    let result = loop {
+        terminal
+            .draw(|frame| render(frame, layout, &timeline, nav, &path.display().to_string()))
+            .map_err(|error| error.to_string())?;
+        match event::read().map_err(|error| error.to_string())? {
+            Event::Key(key) if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) => break Ok(()),
+            Event::Key(key) => nav.key(key.code, timeline.duration_us),
+            _ => {}
+        }
+    };
+    let _ = disable_raw_mode();
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    let _ = terminal.show_cursor();
+    result
+}
+
+fn main() {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let result = (|| {
+        let (capture, layout) = match args.as_slice() {
+            [capture] => (capture.as_str(), None),
+            [capture, flag, layout] if flag == "--layout" => {
+                (capture.as_str(), Some(layout.as_str()))
+            }
+            _ => {
+                return Err(
+                    "usage: obdentic-capture-tui <capture.jsonl> [--layout <layout.tsv>]".into(),
+                );
+            }
+        };
+        let layout = layout.map_or_else(
+            || Ok(offline_engine_overview()),
+            |path| tui::load_layout(Path::new(path)),
+        )?;
+        run_tui(Path::new(capture), &layout)
+    })();
+    if let Err(error) = result {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use obdentic::capture_events::{ReadTiming, ResponderEvidence};
+
+    fn read(semantic: &str, at_us: u64, value: f64, unit: &str) -> CaptureEvent {
+        CaptureEvent::ReadSucceeded {
+            semantic: semantic.into(),
+            requested_interval_us: 1_000_000,
+            due_us: at_us.saturating_sub(100_000),
+            started_us: at_us.saturating_sub(50_000),
+            finished_us: at_us,
+            request_payload: vec![0x01, 0x0c],
+            response_payload: vec![0x41, 0x0c, 0x00, 0x00],
+            value: CaptureValue::Number(value),
+            unit: unit.into(),
+            source: "7E8".into(),
+            profile: "obd2-v1".into(),
+            decoder: "test".into(),
+            provenance: "synthetic".into(),
+        }
+    }
+
+    fn fixture(status: CaptureStatus) -> ParsedCapture {
+        let mut events = vec![
+            CaptureEvent::capture_started(None, Some("engine-drive".into())),
+            CaptureEvent::subscription_configured(
+                "engine.rpm",
+                1_000_000,
+                SubscriptionFilterOutcome::Scheduled,
+            ),
+            CaptureEvent::subscription_configured(
+                "future.signal",
+                1_000_000,
+                SubscriptionFilterOutcome::Unsupported,
+            ),
+            CaptureEvent::responses_observed(
+                "engine.rpm",
+                vec![0x01, 0x0c],
+                vec![ResponderEvidence::new(
+                    Some("7E8".into()),
+                    vec![0x41, 0x0c, 0x0c, 0x80],
+                )
+                .unwrap()],
+                Some("7E8".into()),
+                None,
+            )
+            .unwrap(),
+            read("engine.rpm", 1_000_000, 800.0, "rpm"),
+            read("engine.rpm", 2_500_000, 1_200.0, "rpm"),
+            CaptureEvent::ReadFailed {
+                semantic: "engine.rpm".into(),
+                requested_interval_us: 1_000_000,
+                timing: Some(ReadTiming::new(3_000_000, 3_050_000, 3_200_000)),
+                request_payload: Some(vec![0x01, 0x0c]),
+                error: "conflicting responders".into(),
+            },
+            CaptureEvent::SlotsSkipped {
+                semantic: "engine.rpm".into(),
+                count: 1,
+                first_due_us: 4_000_000,
+                last_due_us: 4_000_000,
+            },
+        ];
+        if status == CaptureStatus::Complete {
+            events.push(CaptureEvent::SessionStopped {
+                offset_us: 5_000_000,
+            });
+        }
+        ParsedCapture { events, status }
+    }
+
+    fn text(terminal: &Terminal<TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn indexes_irregular_timestamps_and_prior_sample() {
+        let timeline = Timeline::from_capture(&fixture(CaptureStatus::Complete));
+        assert_eq!(
+            timeline.current_at("engine.rpm", 2_000_000).unwrap().at_us,
+            1_000_000
+        );
+        assert_eq!(
+            timeline.current_at("engine.rpm", 3_000_000).unwrap().at_us,
+            2_500_000
+        );
+        assert_eq!(
+            numeric(timeline.samples_in("engine.rpm", 0, 5_000_000)),
+            [(1.0, 800.0), (2.5, 1_200.0)]
+        );
+        assert_eq!(
+            timeline.availability("future.signal"),
+            Availability::Unsupported
+        );
+        assert_eq!(timeline.stale_after_us("engine.rpm"), Some(2_000_000));
+    }
+
+    #[test]
+    fn navigation_uses_capture_time() {
+        let mut nav = Nav::new(120_000_000);
+        nav.key(KeyCode::Home, 120_000_000);
+        assert_eq!(nav.cursor_us, 0);
+        nav.key(KeyCode::Right, 120_000_000);
+        assert!(nav.cursor_us > 0);
+        for _ in 0..20 {
+            nav.key(KeyCode::Char('+'), 120_000_000);
+        }
+        assert_eq!(nav.window_us, MIN_WINDOW_US);
+        nav.key(KeyCode::End, 120_000_000);
+        assert_eq!(nav.cursor_us, 120_000_000);
+    }
+
+    #[test]
+    fn evidence_and_problems_never_look_ahead_of_cursor() {
+        let timeline = Timeline::from_capture(&fixture(CaptureStatus::Complete));
+        let layout = DashboardLayout {
+            name: "cursor".into(),
+            panels: vec![Panel {
+                title: "RPM".into(),
+                view: View::Value,
+                signals: vec!["engine.rpm".into()],
+            }],
+        };
+        let mut terminal = Terminal::new(TestBackend::new(140, 35)).unwrap();
+        terminal
+            .draw(|frame| {
+                render(
+                    frame,
+                    &layout,
+                    &timeline,
+                    Nav {
+                        cursor_us: 2_600_000,
+                        window_us: 5_000_000,
+                    },
+                    "fixture.jsonl",
+                )
+            })
+            .unwrap();
+        let output = text(&terminal);
+        assert!(output.contains("TX 01 0C"));
+        assert!(output.contains("Problems (0)"));
+        assert!(!output.contains("conflicting responders"));
+        assert!(!output.contains("skipped"));
+    }
+
+    #[test]
+    fn problems_feed_excludes_routine_runtime_noise() {
+        let timeline = Timeline::from_capture(&fixture(CaptureStatus::Complete));
+        assert!(!is_problem_event(&Evidence {
+            at_us: 1,
+            kind: "runtime",
+            semantic: None,
+            text: "routine state transition".into(),
+        }));
+        assert!(is_problem_event(&Evidence {
+            at_us: 1,
+            kind: "read_error",
+            semantic: Some("engine.rpm".into()),
+            text: "conflict".into(),
+        }));
+        assert!(timeline
+            .evidence
+            .iter()
+            .any(|event| event.kind == "read_error" && is_problem_event(event)));
+    }
+
+    #[test]
+    fn problems_feed_shows_semantic_and_count() {
+        let timeline = Timeline::from_capture(&fixture(CaptureStatus::Complete));
+        let layout = DashboardLayout {
+            name: "problems".into(),
+            panels: vec![Panel {
+                title: "RPM".into(),
+                view: View::Value,
+                signals: vec!["engine.rpm".into()],
+            }],
+        };
+        let mut terminal = Terminal::new(TestBackend::new(140, 35)).unwrap();
+        terminal
+            .draw(|frame| {
+                render(
+                    frame,
+                    &layout,
+                    &timeline,
+                    Nav::new(timeline.duration_us),
+                    "fixture.jsonl",
+                )
+            })
+            .unwrap();
+        let output = text(&terminal);
+        assert!(output.contains("Problems (2)"));
+        assert!(output.contains("engine.rpm"));
+        assert!(output.contains("conflicting responders"));
+        assert!(output.contains("slots=1"));
+    }
+
+    #[test]
+    fn stale_value_is_explicit_at_cursor() {
+        let timeline = Timeline::from_capture(&fixture(CaptureStatus::Complete));
+        let layout = DashboardLayout {
+            name: "stale".into(),
+            panels: vec![Panel {
+                title: "RPM".into(),
+                view: View::Value,
+                signals: vec!["engine.rpm".into()],
+            }],
+        };
+        let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+        terminal
+            .draw(|frame| {
+                render(
+                    frame,
+                    &layout,
+                    &timeline,
+                    Nav {
+                        cursor_us: 5_000_000,
+                        window_us: 5_000_000,
+                    },
+                    "fixture.jsonl",
+                )
+            })
+            .unwrap();
+        assert!(text(&terminal).contains("STALE"));
+    }
+
+    #[test]
+    fn sparkline_segments_preserve_large_capture_time_gaps() {
+        let mut parsed = fixture(CaptureStatus::Complete);
+        parsed
+            .events
+            .push(read("engine.rpm", 8_000_000, 1_500.0, "rpm"));
+        let timeline = Timeline::from_capture(&parsed);
+        let samples = timeline.samples_in("engine.rpm", 0, 10_000_000);
+        let segments = numeric_segments(samples, timeline.stale_after_us("engine.rpm"));
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0], [(1.0, 800.0), (2.5, 1_200.0)]);
+        assert_eq!(segments[1], [(8.0, 1_500.0)]);
+    }
+
+    #[test]
+    fn default_offline_compare_uses_compatible_pressure_signals() {
+        let layout = offline_engine_overview();
+        let compare = layout
+            .panels
+            .iter()
+            .find(|panel| panel.view == View::Compare)
+            .unwrap();
+        assert_eq!(
+            compare.signals,
+            [
+                "engine.intake_manifold_pressure",
+                "engine.barometric_pressure"
+            ]
+        );
+    }
+
+    #[test]
+    fn renders_partial_missing_and_evidence() {
+        let timeline = Timeline::from_capture(&fixture(CaptureStatus::Partial));
+        let layout = DashboardLayout {
+            name: "offline".into(),
+            panels: vec![
+                Panel {
+                    title: "RPM".into(),
+                    view: View::TimeSeries,
+                    signals: vec!["engine.rpm".into()],
+                },
+                Panel {
+                    title: "Missing".into(),
+                    view: View::Value,
+                    signals: vec!["future.signal".into()],
+                },
+            ],
+        };
+        let mut terminal = Terminal::new(TestBackend::new(140, 35)).unwrap();
+        terminal
+            .draw(|frame| {
+                render(
+                    frame,
+                    &layout,
+                    &timeline,
+                    Nav::new(timeline.duration_us),
+                    "fixture.jsonl",
+                )
+            })
+            .unwrap();
+        let output = text(&terminal);
+        assert!(output.contains("PARTIAL"));
+        assert!(output.contains("unsupported / unavailable"));
+        assert!(output.contains("TX 01 0C"));
+        assert!(output.contains("conflicting responders"));
+        assert!(output.contains("skipped"));
+    }
+
+    #[test]
+    fn compare_rejects_incompatible_units() {
+        let mut parsed = fixture(CaptureStatus::Complete);
+        parsed
+            .events
+            .push(read("vehicle.speed", 2_000_000, 50.0, "km/h"));
+        let timeline = Timeline::from_capture(&parsed);
+        let layout = DashboardLayout {
+            name: "compare".into(),
+            panels: vec![Panel {
+                title: "Compare".into(),
+                view: View::Compare,
+                signals: vec!["engine.rpm".into(), "vehicle.speed".into()],
+            }],
+        };
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        terminal
+            .draw(|frame| {
+                render(
+                    frame,
+                    &layout,
+                    &timeline,
+                    Nav::new(timeline.duration_us),
+                    "fixture.jsonl",
+                )
+            })
+            .unwrap();
+        assert!(text(&terminal).contains("incompatible units: rpm vs km/h"));
+    }
+}

--- a/src/capture_replay.rs
+++ b/src/capture_replay.rs
@@ -1,0 +1,333 @@
+//! Deterministic, transport-free replay of successful JSONL capture reads.
+//!
+//! The replay path deliberately re-decodes persisted raw response bytes with the
+//! current semantic decoder instead of trusting the decoded value stored by the
+//! recording version. Original capture evidence remains untouched and replay
+//! differences are reported as issues rather than rewritten.
+
+use crate::{
+    capture_events::{CaptureEvent, CaptureValue},
+    jsonl_capture::ParsedCapture,
+    prepare_read,
+    telemetry::TelemetryState,
+    Transaction,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReplayIssueKind {
+    UnsupportedSemantic,
+    RequestChanged,
+    DecodeFailed,
+    RecordedDecodeChanged,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReplayIssue {
+    at_us: u64,
+    semantic: String,
+    kind: ReplayIssueKind,
+    detail: String,
+}
+
+impl ReplayIssue {
+    pub const fn at_us(&self) -> u64 {
+        self.at_us
+    }
+
+    pub fn semantic(&self) -> &str {
+        &self.semantic
+    }
+
+    pub const fn kind(&self) -> ReplayIssueKind {
+        self.kind
+    }
+
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+pub struct CaptureReplay {
+    duration_us: u64,
+    offsets_us: Vec<u64>,
+    transactions: Vec<Transaction>,
+    issues: Vec<ReplayIssue>,
+}
+
+impl CaptureReplay {
+    /// Re-decode every successful semantic read in a parsed capture.
+    ///
+    /// No transport/session/scheduler object is constructed here. Reads that the
+    /// current catalog can no longer decode are preserved as replay issues and do
+    /// not make the rest of the capture unusable.
+    pub fn from_capture(capture: &ParsedCapture) -> Self {
+        let mut duration_us = 0_u64;
+        let mut decoded = Vec::<(u64, Transaction)>::new();
+        let mut issues = Vec::new();
+
+        for event in &capture.events {
+            match event {
+                CaptureEvent::ReadSucceeded {
+                    semantic,
+                    finished_us,
+                    request_payload,
+                    response_payload,
+                    value,
+                    unit,
+                    source,
+                    ..
+                } => {
+                    duration_us = duration_us.max(*finished_us);
+                    let request = match prepare_read(semantic) {
+                        Ok(request) => request,
+                        Err(error) => {
+                            issues.push(ReplayIssue {
+                                at_us: *finished_us,
+                                semantic: semantic.clone(),
+                                kind: ReplayIssueKind::UnsupportedSemantic,
+                                detail: error,
+                            });
+                            continue;
+                        }
+                    };
+                    if request_payload.as_slice() != request.bytes().as_slice() {
+                        issues.push(ReplayIssue {
+                            at_us: *finished_us,
+                            semantic: semantic.clone(),
+                            kind: ReplayIssueKind::RequestChanged,
+                            detail: format!(
+                                "recorded request {:?} differs from current semantic request {:?}",
+                                request_payload,
+                                request.bytes()
+                            ),
+                        });
+                        continue;
+                    }
+                    let transaction = match request.complete(source, response_payload.clone()) {
+                        Ok(transaction) => {
+                            transaction.with_timestamp_ms(u128::from(*finished_us / 1_000))
+                        }
+                        Err(error) => {
+                            issues.push(ReplayIssue {
+                                at_us: *finished_us,
+                                semantic: semantic.clone(),
+                                kind: ReplayIssueKind::DecodeFailed,
+                                detail: error,
+                            });
+                            continue;
+                        }
+                    };
+                    if recorded_decode_changed(value, unit, &transaction) {
+                        issues.push(ReplayIssue {
+                            at_us: *finished_us,
+                            semantic: semantic.clone(),
+                            kind: ReplayIssueKind::RecordedDecodeChanged,
+                            detail: format!(
+                                "recorded={} {} current={:.6} {}",
+                                capture_value_text(value),
+                                unit,
+                                transaction.value(),
+                                transaction.unit()
+                            ),
+                        });
+                    }
+                    decoded.push((*finished_us, transaction));
+                }
+                CaptureEvent::ReadFailed {
+                    timing: Some(timing),
+                    ..
+                } => {
+                    duration_us = duration_us.max(timing.finished_us);
+                }
+                CaptureEvent::ReadFailed { timing: None, .. } => {}
+                CaptureEvent::SlotsSkipped { last_due_us, .. } => {
+                    duration_us = duration_us.max(*last_due_us);
+                }
+                CaptureEvent::SessionStopped { offset_us } => {
+                    duration_us = duration_us.max(*offset_us);
+                }
+                _ => {}
+            }
+        }
+
+        decoded.sort_by_key(|(at_us, _)| *at_us);
+        let (offsets_us, transactions): (Vec<_>, Vec<_>) = decoded.into_iter().unzip();
+        issues.sort_by_key(ReplayIssue::at_us);
+        Self {
+            duration_us,
+            offsets_us,
+            transactions,
+            issues,
+        }
+    }
+
+    pub const fn duration_us(&self) -> u64 {
+        self.duration_us
+    }
+
+    pub fn offsets_us(&self) -> &[u64] {
+        &self.offsets_us
+    }
+
+    pub fn transactions(&self) -> &[Transaction] {
+        &self.transactions
+    }
+
+    pub fn issues(&self) -> &[ReplayIssue] {
+        &self.issues
+    }
+
+    pub fn telemetry_at(&self, cursor_us: u64, capacity: usize) -> Result<TelemetryState, String> {
+        let mut state = TelemetryState::new(capacity)?;
+        let end = self.offsets_us.partition_point(|at_us| *at_us <= cursor_us);
+        for transaction in &self.transactions[..end] {
+            state.ingest(transaction);
+        }
+        Ok(state)
+    }
+
+    pub fn telemetry_full(&self, capacity: usize) -> Result<TelemetryState, String> {
+        self.telemetry_at(self.duration_us, capacity)
+    }
+}
+
+fn recorded_decode_changed(value: &CaptureValue, unit: &str, transaction: &Transaction) -> bool {
+    unit != transaction.unit()
+        || match value {
+            CaptureValue::Number(recorded) => *recorded != transaction.value(),
+            _ => true,
+        }
+}
+
+fn capture_value_text(value: &CaptureValue) -> String {
+    match value {
+        CaptureValue::Number(value) => format!("{value:.6}"),
+        CaptureValue::Boolean(value) => value.to_string(),
+        CaptureValue::Enum(value) | CaptureValue::Text(value) => value.clone(),
+        CaptureValue::Unavailable { reason } => format!("unavailable({reason})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{capture_events::ReadTiming, jsonl_capture::CaptureStatus};
+
+    fn successful_read(
+        semantic: &str,
+        at_us: u64,
+        request: Vec<u8>,
+        response: Vec<u8>,
+        recorded_value: f64,
+        unit: &str,
+    ) -> CaptureEvent {
+        CaptureEvent::ReadSucceeded {
+            semantic: semantic.into(),
+            requested_interval_us: 1_000_000,
+            due_us: at_us.saturating_sub(100_000),
+            started_us: at_us.saturating_sub(50_000),
+            finished_us: at_us,
+            request_payload: request,
+            response_payload: response,
+            value: CaptureValue::Number(recorded_value),
+            unit: unit.into(),
+            source: "user".into(),
+            profile: "obd2-v1".into(),
+            decoder: "recorded-decoder".into(),
+            provenance: "recorded-provenance".into(),
+        }
+    }
+
+    fn capture(events: Vec<CaptureEvent>) -> ParsedCapture {
+        ParsedCapture {
+            events,
+            status: CaptureStatus::Complete,
+        }
+    }
+
+    #[test]
+    fn raw_response_is_redecoded_instead_of_trusting_recorded_value() {
+        let replay = CaptureReplay::from_capture(&capture(vec![
+            successful_read(
+                "engine.rpm",
+                1_234_567,
+                vec![0x01, 0x0c],
+                vec![0x41, 0x0c, 0x0c, 0x80],
+                9_999.0,
+                "rpm",
+            ),
+            CaptureEvent::SessionStopped {
+                offset_us: 2_000_000,
+            },
+        ]));
+
+        assert_eq!(replay.transactions().len(), 1);
+        assert_eq!(replay.offsets_us(), [1_234_567]);
+        assert_eq!(replay.transactions()[0].value(), 800.0);
+        assert_eq!(replay.transactions()[0].timestamp_ms(), 1_234);
+        assert_eq!(replay.duration_us(), 2_000_000);
+        assert_eq!(replay.issues().len(), 1);
+        assert_eq!(
+            replay.issues()[0].kind(),
+            ReplayIssueKind::RecordedDecodeChanged
+        );
+    }
+
+    #[test]
+    fn telemetry_cursor_never_ingests_future_reads() {
+        let replay = CaptureReplay::from_capture(&capture(vec![
+            successful_read(
+                "engine.rpm",
+                1_000_000,
+                vec![0x01, 0x0c],
+                vec![0x41, 0x0c, 0x0c, 0x80],
+                800.0,
+                "rpm",
+            ),
+            successful_read(
+                "engine.rpm",
+                3_000_000,
+                vec![0x01, 0x0c],
+                vec![0x41, 0x0c, 0x12, 0xc0],
+                1_200.0,
+                "rpm",
+            ),
+        ]));
+
+        let before = replay.telemetry_at(2_000_000, 8).unwrap();
+        assert_eq!(before.current("engine.rpm").unwrap().value, 800.0);
+        let after = replay.telemetry_at(3_000_000, 8).unwrap();
+        assert_eq!(after.current("engine.rpm").unwrap().value, 1_200.0);
+    }
+
+    #[test]
+    fn request_drift_is_reported_and_not_replayed() {
+        let replay = CaptureReplay::from_capture(&capture(vec![successful_read(
+            "engine.rpm",
+            1_000_000,
+            vec![0x01, 0x0d],
+            vec![0x41, 0x0c, 0x0c, 0x80],
+            800.0,
+            "rpm",
+        )]));
+
+        assert!(replay.transactions().is_empty());
+        assert_eq!(replay.issues().len(), 1);
+        assert_eq!(replay.issues()[0].kind(), ReplayIssueKind::RequestChanged);
+    }
+
+    #[test]
+    fn failed_reads_affect_duration_but_never_create_telemetry() {
+        let replay = CaptureReplay::from_capture(&capture(vec![CaptureEvent::ReadFailed {
+            semantic: "engine.rpm".into(),
+            requested_interval_us: 1_000_000,
+            timing: Some(ReadTiming::new(4_000_000, 4_050_000, 4_200_000)),
+            request_payload: Some(vec![0x01, 0x0c]),
+            error: "conflicting responders".into(),
+        }]));
+
+        assert_eq!(replay.duration_us(), 4_200_000);
+        assert!(replay.transactions().is_empty());
+        assert!(replay.telemetry_full(4).unwrap().signals().next().is_none());
+    }
+}

--- a/src/capture_replay.rs
+++ b/src/capture_replay.rs
@@ -165,6 +165,7 @@ impl CaptureReplay {
         self.duration_us
     }
 
+    /// Exact monotonic JSONL timestamps aligned one-to-one with [`Self::transactions`].
     pub fn offsets_us(&self) -> &[u64] {
         &self.offsets_us
     }
@@ -180,8 +181,12 @@ impl CaptureReplay {
     pub fn telemetry_at(&self, cursor_us: u64, capacity: usize) -> Result<TelemetryState, String> {
         let mut state = TelemetryState::new(capacity)?;
         let end = self.offsets_us.partition_point(|at_us| *at_us <= cursor_us);
-        for transaction in &self.transactions[..end] {
-            state.ingest(transaction);
+        for (timestamp_us, transaction) in self.offsets_us[..end]
+            .iter()
+            .copied()
+            .zip(&self.transactions[..end])
+        {
+            state.ingest_at_us(transaction, u128::from(timestamp_us));
         }
         Ok(state)
     }
@@ -298,6 +303,45 @@ mod tests {
         assert_eq!(before.current("engine.rpm").unwrap().value, 800.0);
         let after = replay.telemetry_at(3_000_000, 8).unwrap();
         assert_eq!(after.current("engine.rpm").unwrap().value, 1_200.0);
+    }
+
+    #[test]
+    fn replay_preserves_distinct_submillisecond_capture_offsets_in_telemetry() {
+        let replay = CaptureReplay::from_capture(&capture(vec![
+            successful_read(
+                "engine.rpm",
+                1_000_001,
+                vec![0x01, 0x0c],
+                vec![0x41, 0x0c, 0x00, 0x04],
+                1.0,
+                "rpm",
+            ),
+            successful_read(
+                "engine.rpm",
+                1_000_999,
+                vec![0x01, 0x0c],
+                vec![0x41, 0x0c, 0x00, 0x08],
+                2.0,
+                "rpm",
+            ),
+        ]));
+
+        let state = replay.telemetry_full(8).unwrap();
+        let exact = state
+            .timed_history("engine.rpm")
+            .unwrap()
+            .map(|(timestamp_us, sample)| (timestamp_us, sample.value))
+            .collect::<Vec<_>>();
+        assert_eq!(exact, [(1_000_001, 1.0), (1_000_999, 2.0)]);
+        assert_eq!(
+            state
+                .history("engine.rpm")
+                .unwrap()
+                .iter()
+                .map(|sample| sample.timestamp_ms)
+                .collect::<Vec<_>>(),
+            [1_000, 1_000]
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cache_validation;
 pub mod capability;
 pub mod capture;
 pub mod capture_events;
+pub mod capture_replay;
 pub mod capture_report;
 pub mod diagnostic_job;
 pub mod dtc;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -12,6 +12,7 @@ pub struct Sample {
 pub struct TelemetryState {
     capacity: usize,
     samples: BTreeMap<&'static str, VecDeque<Sample>>,
+    timestamps_us: BTreeMap<&'static str, VecDeque<u128>>,
 }
 
 impl TelemetryState {
@@ -20,26 +21,45 @@ impl TelemetryState {
             .then_some(Self {
                 capacity,
                 samples: BTreeMap::new(),
+                timestamps_us: BTreeMap::new(),
             })
             .ok_or_else(|| "telemetry capacity must be greater than zero".into())
     }
 
     pub fn ingest(&mut self, transaction: &Transaction) {
-        let samples = self.samples.entry(transaction.semantic()).or_default();
+        self.ingest_at_us(
+            transaction,
+            transaction.timestamp_ms().saturating_mul(1_000),
+        );
+    }
+
+    /// Ingest a decoded transaction while preserving an exact monotonic timestamp.
+    ///
+    /// Live callers normally use [`Self::ingest`]. Offline capture replay uses this
+    /// method so JSONL microsecond offsets remain canonical even though the legacy
+    /// [`Sample::timestamp_ms`] compatibility field is only millisecond precision.
+    pub fn ingest_at_us(&mut self, transaction: &Transaction, timestamp_us: u128) {
+        let semantic = transaction.semantic();
+        let samples = self.samples.entry(semantic).or_default();
+        let timestamps = self.timestamps_us.entry(semantic).or_default();
+        debug_assert_eq!(samples.len(), timestamps.len());
+
         let sample = Sample {
-            timestamp_ms: transaction.timestamp_ms(),
+            timestamp_ms: timestamp_us / 1_000,
             value: transaction.value(),
             unit: transaction.unit(),
         };
-        // ponytail: histories cap at 600 samples; use a time-indexed store if much larger out-of-order streams arrive.
-        let position = samples
+        let position = timestamps
             .iter()
-            .position(|current| current.timestamp_ms > sample.timestamp_ms)
-            .unwrap_or(samples.len());
+            .position(|current| *current > timestamp_us)
+            .unwrap_or(timestamps.len());
+        timestamps.insert(position, timestamp_us);
         samples.insert(position, sample);
         if samples.len() > self.capacity {
             samples.pop_front();
+            timestamps.pop_front();
         }
+        debug_assert_eq!(samples.len(), timestamps.len());
     }
 
     pub fn current(&self, semantic: &str) -> Option<&Sample> {
@@ -48,6 +68,21 @@ impl TelemetryState {
 
     pub fn history(&self, semantic: &str) -> Option<&VecDeque<Sample>> {
         self.samples.get(semantic)
+    }
+
+    /// Iterate a signal history with its exact timestamp in microseconds.
+    ///
+    /// The timestamps are kept in lock-step with [`Self::history`]. This is the
+    /// canonical time axis for offline JSONL replay and avoids collapsing distinct
+    /// samples that happen within the same millisecond.
+    pub fn timed_history(
+        &self,
+        semantic: &str,
+    ) -> Option<impl Iterator<Item = (u128, &Sample)> + '_> {
+        let samples = self.samples.get(semantic)?;
+        let timestamps = self.timestamps_us.get(semantic)?;
+        debug_assert_eq!(samples.len(), timestamps.len());
+        Some(timestamps.iter().copied().zip(samples.iter()))
     }
 
     pub fn signals(&self) -> impl Iterator<Item = &'static str> + '_ {
@@ -86,6 +121,14 @@ mod tests {
                 .collect::<Vec<_>>(),
             [2, 3]
         );
+        assert_eq!(
+            state
+                .timed_history("engine.rpm")
+                .unwrap()
+                .map(|(timestamp_us, _)| timestamp_us)
+                .collect::<Vec<_>>(),
+            [2_000, 3_000]
+        );
         assert_eq!(state.signals().collect::<Vec<_>>(), ["engine.rpm"]);
     }
 
@@ -102,6 +145,7 @@ mod tests {
         assert_eq!(state.current("vehicle.speed").unwrap().value, 50.0);
         assert!(state.current("dpf.diff_pressure").is_none());
         assert!(state.history("dpf.diff_pressure").is_none());
+        assert!(state.timed_history("dpf.diff_pressure").is_none());
         assert!(TelemetryState::new(0).is_err());
     }
 
@@ -122,5 +166,31 @@ mod tests {
             [2, 3]
         );
         assert_eq!(state.current("engine.rpm").unwrap().value, 3.0);
+    }
+
+    #[test]
+    fn exact_microsecond_timeline_distinguishes_samples_within_one_millisecond() {
+        let mut state = TelemetryState::new(4).unwrap();
+        let first = transaction(0, vec![0x41, 0x0c, 0x00, 0x04]);
+        let second = transaction(0, vec![0x41, 0x0c, 0x00, 0x08]);
+        state.ingest_at_us(&second, 1_000_999);
+        state.ingest_at_us(&first, 1_000_001);
+
+        assert_eq!(
+            state
+                .history("engine.rpm")
+                .unwrap()
+                .iter()
+                .map(|sample| sample.timestamp_ms)
+                .collect::<Vec<_>>(),
+            [1_000, 1_000]
+        );
+        let exact = state
+            .timed_history("engine.rpm")
+            .unwrap()
+            .map(|(timestamp_us, sample)| (timestamp_us, sample.value))
+            .collect::<Vec<_>>();
+        assert_eq!(exact, [(1_000_001, 1.0), (1_000_999, 2.0)]);
+        assert_eq!(state.current("engine.rpm").unwrap().value, 2.0);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -748,10 +748,7 @@ mod tests {
             unit: "rpm",
         }]);
         assert_eq!(
-            time_points_from(
-                [1_000_000_u128].into_iter().zip(compatible.iter()),
-                0,
-            ),
+            time_points_from([1_000_000_u128].into_iter().zip(compatible.iter()), 0,),
             [(1.0, 1.0)]
         );
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -458,7 +458,13 @@ fn render_time_series(frame: &mut Frame, area: Rect, state: &TelemetryState, pan
     let Some(history) = state.history(signal).filter(|history| !history.is_empty()) else {
         return unsupported(frame, area, panel, signal);
     };
-    let points = time_points_from(history, history.front().unwrap().timestamp_ms);
+    let Some(origin_us) = state
+        .timed_history(signal)
+        .and_then(|mut history| history.next().map(|(timestamp_us, _)| timestamp_us))
+    else {
+        return unsupported(frame, area, panel, signal);
+    };
+    let points = time_points_from(state.timed_history(signal).unwrap(), origin_us);
     let (x_minimum, x_maximum, y_minimum, y_maximum) = chart_bounds(&points, &[]);
     let chart = Chart::new(vec![Dataset::default()
         .name(signal)
@@ -508,12 +514,14 @@ fn sparkline_values(history: Option<&VecDeque<Sample>>) -> Vec<u64> {
         .collect()
 }
 
-fn time_points_from(history: &VecDeque<Sample>, origin: u128) -> Vec<(f64, f64)> {
+fn time_points_from<'a>(
+    history: impl Iterator<Item = (u128, &'a Sample)>,
+    origin_us: u128,
+) -> Vec<(f64, f64)> {
     history
-        .iter()
-        .map(|sample| {
+        .map(|(timestamp_us, sample)| {
             (
-                sample.timestamp_ms.saturating_sub(origin) as f64 / 1_000.0,
+                timestamp_us.saturating_sub(origin_us) as f64 / 1_000_000.0,
                 sample.value,
             )
         })
@@ -546,9 +554,18 @@ fn render_compare(frame: &mut Frame, area: Rect, state: &TelemetryState, panel: 
         );
         return;
     }
-    let origin = left_unit.timestamp_ms.min(right_unit.timestamp_ms);
-    let left_points = time_points_from(left_history, origin);
-    let right_points = time_points_from(right_history, origin);
+    let left_origin = state
+        .timed_history(left)
+        .and_then(|mut history| history.next().map(|(timestamp_us, _)| timestamp_us));
+    let right_origin = state
+        .timed_history(right)
+        .and_then(|mut history| history.next().map(|(timestamp_us, _)| timestamp_us));
+    let (Some(left_origin), Some(right_origin)) = (left_origin, right_origin) else {
+        return unsupported(frame, area, panel, format!("{left} / {right}"));
+    };
+    let origin_us = left_origin.min(right_origin);
+    let left_points = time_points_from(state.timed_history(left).unwrap(), origin_us);
+    let right_points = time_points_from(state.timed_history(right).unwrap(), origin_us);
     let (x_minimum, x_maximum, y_minimum, y_maximum) = chart_bounds(&left_points, &right_points);
     let chart = Chart::new(vec![
         Dataset::default()
@@ -688,7 +705,7 @@ mod tests {
     }
 
     #[test]
-    fn chart_data_respects_sample_order_timestamps_and_units() {
+    fn chart_data_respects_exact_sample_timestamps_and_units() {
         let history = VecDeque::from([
             Sample {
                 timestamp_ms: 1_000,
@@ -716,7 +733,12 @@ mod tests {
             [1]
         );
         assert_eq!(
-            time_points_from(&history, 1_000),
+            time_points_from(
+                [1_000_000_u128, 2_500_000, 6_000_000]
+                    .into_iter()
+                    .zip(history.iter()),
+                1_000_000,
+            ),
             [(0.0, 1.0), (1.5, 3.0), (5.0, 2.0)]
         );
 
@@ -725,7 +747,35 @@ mod tests {
             value: 1.0,
             unit: "rpm",
         }]);
-        assert_eq!(time_points_from(&compatible, 0), [(1.0, 1.0)]);
+        assert_eq!(
+            time_points_from(
+                [1_000_000_u128].into_iter().zip(compatible.iter()),
+                0,
+            ),
+            [(1.0, 1.0)]
+        );
+
+        let submillisecond = VecDeque::from([
+            Sample {
+                timestamp_ms: 1_000,
+                value: 1.0,
+                unit: "rpm",
+            },
+            Sample {
+                timestamp_ms: 1_000,
+                value: 2.0,
+                unit: "rpm",
+            },
+        ]);
+        let points = time_points_from(
+            [1_000_001_u128, 1_000_999]
+                .into_iter()
+                .zip(submillisecond.iter()),
+            1_000_001,
+        );
+        assert_eq!(points[0], (0.0, 1.0));
+        assert!((points[1].0 - 0.000_998).abs() < 1e-12);
+        assert_eq!(points[1].1, 2.0);
     }
 
     #[test]


### PR DESCRIPTION
Partial implementation of #17, split cleanly from the broader M5/#18 draft so the parallel coding agent can consume the offline replay/TUI dependency independently.

Adds two strictly transport-free entry points:

```bash
cargo run --bin obdentic-capture-tui -- evidence/12-drive.jsonl
cargo run --bin obdentic-capture-replay -- evidence/12-drive.jsonl
```

The capture explorer provides exact monotonic timeline navigation, semantic panels, explicit stale/missing/partial states, gap-preserving charts, TX/RX evidence and a separate Problems feed.

The new replay path provides the missing semantic reconstruction seam:

```text
JSONL ReadSucceeded raw response evidence
  -> current semantic allowlist/request
  -> current deterministic decoder
  -> Transaction
  -> TelemetryState
  -> TUI / semantic snapshot consumer
```

Replay deliberately does not trust the decoded value stored by the recording version. Decoder differences, unsupported semantics, request-definition drift and decode failures are explicit replay issues; original capture evidence is never rewritten. Failed reads never become invented telemetry. No BLE/session/scheduler object is created by replay.

This branch starts from current `main` including merged PR #66 / passive `engine.snapshot`. It intentionally contains none of #18's layout-observation code.

#17 remains open after this PR: canonical `obdentic tui capture <capture.jsonl> [--layout ...]` main-CLI wiring is still the final integration step.

The exact same files passed CI on the M5 branch in run 33203779074 (fmt/tests/clippy `-D warnings`/build); this PR should run its own CI as the merge gate.