### PR TITLE
Add layout observation requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ cargo run -- layout save engine-overview engine-overview.tsv
 cargo run -- tui demo --layout engine-overview.tsv
 ```
 
+In live mode, a layout expresses only semantic observation demand. OBDentic
+passes that demand through the hardware-capability policy and displays the
+requested and effective intervals; layouts never contain polling or protocol
+commands.
+
 This keeps presentation independent from transport and vehicle addressing, which is also the model intended for the future agent interface.
 
 ## Development rule of thumb

--- a/src/layout_observation.rs
+++ b/src/layout_observation.rs
@@ -1,0 +1,286 @@
+use crate::{
+    subscription_policy::{ObservationRequest, PollingPlan, SubscriptionPolicy},
+    tui::{DashboardLayout, View},
+};
+use std::time::Duration;
+
+const LAYOUT_SOURCE_PREFIX: &str = "layout:";
+
+/// Presentation freshness intent kept outside the persisted layout format.
+///
+/// These intervals are requests, not guarantees. `SubscriptionPolicy` remains
+/// the sole authority for the effective polling plan.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LayoutFreshnessPolicy {
+    value: Duration,
+    sparkline: Duration,
+    time_series: Duration,
+    compare: Duration,
+}
+
+impl LayoutFreshnessPolicy {
+    pub fn new(
+        value: Duration,
+        sparkline: Duration,
+        time_series: Duration,
+        compare: Duration,
+    ) -> Result<Self, String> {
+        if [value, sparkline, time_series, compare]
+            .into_iter()
+            .any(|interval| interval.is_zero())
+        {
+            return Err("layout freshness intervals must be greater than zero".into());
+        }
+        Ok(Self {
+            value,
+            sparkline,
+            time_series,
+            compare,
+        })
+    }
+
+    pub const fn desired_interval(self, view: View) -> Duration {
+        match view {
+            View::Value => self.value,
+            View::Sparkline => self.sparkline,
+            View::TimeSeries => self.time_series,
+            View::Compare => self.compare,
+        }
+    }
+}
+
+impl Default for LayoutFreshnessPolicy {
+    fn default() -> Self {
+        Self {
+            value: Duration::from_secs(1),
+            sparkline: Duration::from_millis(200),
+            time_series: Duration::from_millis(500),
+            compare: Duration::from_millis(500),
+        }
+    }
+}
+
+/// Side-effect-free semantic demand derived from a presentation layout.
+///
+/// This function performs no vehicle I/O and cannot construct protocol bytes.
+/// Unknown semantic names remain semantic demand only; the downstream
+/// `SubscriptionPolicy` marks them unsupported unless the active vehicle
+/// catalog explicitly advertises them.
+pub fn observation_requests(
+    layout: &DashboardLayout,
+    freshness: LayoutFreshnessPolicy,
+) -> Result<Vec<ObservationRequest>, String> {
+    if layout.name.trim().is_empty() {
+        return Err("layout observation source requires a non-empty layout name".into());
+    }
+    let source = format!("{LAYOUT_SOURCE_PREFIX}{}", layout.name);
+    let mut requests = Vec::new();
+    for panel in &layout.panels {
+        let desired_interval = freshness.desired_interval(panel.view);
+        for semantic in &panel.signals {
+            requests.push(
+                ObservationRequest::new(&source, semantic, desired_interval)
+                    .map_err(|error| error.to_string())?,
+            );
+        }
+    }
+    Ok(requests)
+}
+
+/// Derive semantic layout demand and pass it through the existing
+/// budget/support policy. The returned plan exposes requested and effective
+/// intervals and each signal's status and reason.
+pub fn polling_plan<Supported, Name>(
+    layout: &DashboardLayout,
+    freshness: LayoutFreshnessPolicy,
+    policy: SubscriptionPolicy,
+    supported_semantics: Supported,
+) -> Result<PollingPlan, String>
+where
+    Supported: IntoIterator<Item = Name>,
+    Name: AsRef<str>,
+{
+    let requests = observation_requests(layout, freshness)?;
+    Ok(policy.plan(&requests, supported_semantics))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        capability::{CapabilityProvenance, HardwareCapability},
+        subscription_policy::{PlanReason, PlanStatus},
+        tui::{engine_overview, Panel},
+    };
+
+    fn policy(requests_per_second: u32) -> SubscriptionPolicy {
+        SubscriptionPolicy::new(
+            HardwareCapability::new(
+                requests_per_second,
+                Duration::from_millis(250),
+                CapabilityProvenance::BuiltInDefault,
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn built_in_layout_derives_only_explicit_semantic_demand() {
+        let layout = engine_overview();
+        let requests = observation_requests(&layout, LayoutFreshnessPolicy::default()).unwrap();
+        assert_eq!(requests.len(), 7);
+        assert!(requests
+            .iter()
+            .all(|request| request.source() == "layout:engine-overview"));
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.semantic() == "engine.rpm")
+                .count(),
+            3
+        );
+        assert_eq!(
+            requests
+                .iter()
+                .map(ObservationRequest::semantic)
+                .collect::<Vec<_>>(),
+            [
+                "engine.rpm",
+                "engine.rpm",
+                "engine.coolant_temperature",
+                "engine.maf",
+                "vehicle.speed",
+                "engine.rpm",
+                "engine.maf",
+            ]
+        );
+        assert_eq!(requests[0].desired_interval(), Duration::from_secs(1));
+        assert_eq!(requests[1].desired_interval(), Duration::from_millis(200));
+        assert_eq!(requests[5].desired_interval(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn compare_derives_exactly_two_requests() {
+        let layout = DashboardLayout {
+            name: "compare".into(),
+            panels: vec![Panel {
+                title: "Compare".into(),
+                view: View::Compare,
+                signals: vec!["engine.rpm".into(), "engine.maf".into()],
+            }],
+        };
+        let requests = observation_requests(&layout, LayoutFreshnessPolicy::default()).unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].semantic(), "engine.rpm");
+        assert_eq!(requests[1].semantic(), "engine.maf");
+        assert_eq!(requests[0].desired_interval(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn duplicate_layout_demand_merges_only_in_subscription_policy() {
+        let layout = engine_overview();
+        let plan = polling_plan(
+            &layout,
+            LayoutFreshnessPolicy::default(),
+            policy(20),
+            [
+                "engine.rpm",
+                "engine.coolant_temperature",
+                "engine.maf",
+                "vehicle.speed",
+            ],
+        )
+        .unwrap();
+        assert_eq!(plan.entries().len(), 4);
+        let rpm = plan
+            .entries()
+            .iter()
+            .find(|entry| entry.semantic() == "engine.rpm")
+            .unwrap();
+        assert_eq!(rpm.requested_interval(), Duration::from_millis(200));
+        assert_eq!(rpm.status(), PlanStatus::Accepted);
+    }
+
+    #[test]
+    fn unknown_semantic_stays_visible_and_never_becomes_protocol_input() {
+        let layout = DashboardLayout {
+            name: "unknown".into(),
+            panels: vec![Panel {
+                title: "Unknown".into(),
+                view: View::Value,
+                signals: vec!["vehicle.future_fact".into()],
+            }],
+        };
+        let requests = observation_requests(&layout, LayoutFreshnessPolicy::default()).unwrap();
+        assert_eq!(requests[0].semantic(), "vehicle.future_fact");
+        let plan = polling_plan(
+            &layout,
+            LayoutFreshnessPolicy::default(),
+            policy(4),
+            ["engine.rpm"],
+        )
+        .unwrap();
+        let entry = &plan.entries()[0];
+        assert_eq!(entry.semantic(), "vehicle.future_fact");
+        assert_eq!(entry.status(), PlanStatus::Unsupported);
+        assert_eq!(entry.reason(), PlanReason::SignalUnsupported);
+        assert_eq!(entry.effective_interval(), None);
+        assert_eq!(plan.scheduled_entries().count(), 0);
+    }
+
+    #[test]
+    fn budget_reduction_is_explicit_in_the_plan() {
+        let layout = DashboardLayout {
+            name: "busy".into(),
+            panels: vec![
+                Panel {
+                    title: "RPM".into(),
+                    view: View::TimeSeries,
+                    signals: vec!["engine.rpm".into()],
+                },
+                Panel {
+                    title: "MAF".into(),
+                    view: View::TimeSeries,
+                    signals: vec!["engine.maf".into()],
+                },
+            ],
+        };
+        let freshness = LayoutFreshnessPolicy::new(
+            Duration::from_millis(100),
+            Duration::from_millis(100),
+            Duration::from_millis(100),
+            Duration::from_millis(100),
+        )
+        .unwrap();
+        let plan =
+            polling_plan(&layout, freshness, policy(4), ["engine.rpm", "engine.maf"]).unwrap();
+        assert!(plan.entries().iter().all(|entry| {
+            entry.status() == PlanStatus::RateReduced
+                && entry.reason() == PlanReason::SessionRequestBudget
+                && entry.effective_interval() > Some(entry.requested_interval())
+        }));
+        assert!(plan.effective_request_rate_per_second() <= 4.0);
+    }
+
+    #[test]
+    fn freshness_is_not_part_of_persisted_layout_data() {
+        let layout = engine_overview();
+        let debug = format!("{layout:?}");
+        assert!(!debug.contains("interval"));
+        assert!(!debug.contains("request_payload"));
+        assert!(!debug.contains("can"));
+        assert!(!debug.contains("uds"));
+        assert!(!debug.contains("elm"));
+    }
+
+    #[test]
+    fn rejects_zero_freshness() {
+        assert!(LayoutFreshnessPolicy::new(
+            Duration::ZERO,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+        )
+        .is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod evidence;
 pub mod functional_discovery;
 pub mod identity;
 pub mod jsonl_capture;
+pub mod layout_observation;
 pub mod protocol;
 pub mod runtime_actor;
 pub mod runtime_reducer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,18 @@ use obdentic::vehicle_knowledge::{
 };
 use obdentic::{
     audit::AuditState,
-    ble, capture,
+    ble,
+    capability::HardwareCapability,
+    capture,
     capture_events::{
         CaptureEvent, CaptureSubscription, DiagnosticJobStepStatus, DtcObservationFact,
         DtcTransportOutcome, SubscriptionFilterOutcome,
     },
     capture_report, capture_tui,
     diagnostic_job::{DiagnosticJob, DiagnosticScope, JobStatus},
-    dtc, hex, jsonl_capture, prepare_read, record, replay,
+    dtc, hex, jsonl_capture,
+    layout_observation::{self, LayoutFreshnessPolicy},
+    prepare_read, record, replay,
     runtime_actor::RuntimeClient,
     runtime_reducer::RuntimeEvent,
     runtime_state::{
@@ -20,6 +24,7 @@ use obdentic::{
     },
     safety::{DtcReadKind, Operation, OperationRequest, SafetyPolicy},
     scheduler::{apply_runtime_event, ObservationPlan, Subscription, TelemetryScheduler},
+    subscription_policy::SubscriptionPolicy,
     supported_signals,
     telemetry::TelemetryState,
     topology::{
@@ -229,78 +234,88 @@ async fn run() -> Result<(), String> {
                 layout,
                 recording,
             } => {
+                let layout = load_layout(layout.as_deref())?;
+                let advertised = ble::supported_signals(&adapter_id).await?;
+                let (policy, subscriptions) = planned_layout_subscriptions(&layout, &advertised)?;
+                let policy_state = Arc::new(Mutex::new(policy));
                 let telemetry = Arc::new(Mutex::new(TelemetryState::new(600)?));
                 let audit = Arc::new(Mutex::new(AuditState::new(600)?));
-                let plans = routed_observation_plans(&adapter_id, live_subscriptions()?).await?;
-                let (recorder, writer) = match recording.as_deref() {
-                    Some(path) => {
-                        let (sender, writer) = jsonl_capture::start(Path::new(path))?;
-                        (Some(sender), Some(writer))
-                    }
-                    None => (None, None),
-                };
-                if let Some(sender) = recorder.as_ref() {
-                    apply_runtime_event(
-                        &runtime,
-                        &mut runtime_state,
-                        Some(sender),
-                        RuntimeEvent::recording(RecordingState::Active),
-                    )
-                    .await?;
-                }
-                let scheduler = match TelemetryScheduler::start_with_runtime(
-                    &adapter_id,
-                    plans,
-                    telemetry.clone(),
-                    audit.clone(),
-                    recorder.clone(),
-                    None,
-                    None,
-                    runtime.clone(),
-                )
-                .await
-                {
-                    Ok(scheduler) => scheduler,
-                    Err(error) => {
-                        if let Some(sender) = recorder.as_ref() {
-                            apply_runtime_event(
-                                &runtime,
-                                &mut runtime_state,
-                                Some(sender),
-                                RuntimeEvent::recording(RecordingState::Inactive),
-                            )
-                            .await?;
+                if subscriptions.is_empty() {
+                    tui::run_live(&layout, telemetry, audit, policy_state)
+                } else {
+                    let plans = routed_observation_plans(&adapter_id, subscriptions).await?;
+                    let (recorder, writer) = match recording.as_deref() {
+                        Some(path) => {
+                            let (sender, writer) = jsonl_capture::start(Path::new(path))?;
+                            (Some(sender), Some(writer))
                         }
-                        let shutdown =
-                            finish_runtime(&runtime, &mut runtime_state, recorder.as_ref()).await;
-                        let recorded = finish_capture(recorder, writer).await;
-                        shutdown?;
-                        recorded?;
-                        return Err(error);
+                        None => (None, None),
+                    };
+                    if let Some(sender) = recorder.as_ref() {
+                        apply_runtime_event(
+                            &runtime,
+                            &mut runtime_state,
+                            Some(sender),
+                            RuntimeEvent::recording(RecordingState::Active),
+                        )
+                        .await?;
                     }
-                };
-                let result = tui::run_live(&load_layout(layout.as_deref())?, telemetry, audit);
-                let stopped = scheduler.stop().await;
-                let inactive = if let Some(sender) = recorder.as_ref() {
-                    apply_runtime_event(
-                        &runtime,
-                        &mut runtime_state,
-                        Some(sender),
-                        RuntimeEvent::recording(RecordingState::Inactive),
+                    let scheduler = match TelemetryScheduler::start_with_runtime(
+                        &adapter_id,
+                        plans,
+                        telemetry.clone(),
+                        audit.clone(),
+                        recorder.clone(),
+                        None,
+                        None,
+                        runtime.clone(),
+                        Some(policy_state.clone()),
                     )
                     .await
-                } else {
+                    {
+                        Ok(scheduler) => scheduler,
+                        Err(error) => {
+                            if let Some(sender) = recorder.as_ref() {
+                                apply_runtime_event(
+                                    &runtime,
+                                    &mut runtime_state,
+                                    Some(sender),
+                                    RuntimeEvent::recording(RecordingState::Inactive),
+                                )
+                                .await?;
+                            }
+                            let shutdown =
+                                finish_runtime(&runtime, &mut runtime_state, recorder.as_ref())
+                                    .await;
+                            let recorded = finish_capture(recorder, writer).await;
+                            shutdown?;
+                            recorded?;
+                            return Err(error);
+                        }
+                    };
+                    let result = tui::run_live(&layout, telemetry, audit, policy_state);
+                    let stopped = scheduler.stop().await;
+                    let inactive = if let Some(sender) = recorder.as_ref() {
+                        apply_runtime_event(
+                            &runtime,
+                            &mut runtime_state,
+                            Some(sender),
+                            RuntimeEvent::recording(RecordingState::Inactive),
+                        )
+                        .await
+                    } else {
+                        Ok(())
+                    };
+                    let shutdown =
+                        finish_runtime(&runtime, &mut runtime_state, recorder.as_ref()).await;
+                    let recorded = finish_capture(recorder, writer).await;
+                    result?;
+                    stopped?;
+                    inactive?;
+                    shutdown?;
+                    recorded?;
                     Ok(())
-                };
-                let shutdown =
-                    finish_runtime(&runtime, &mut runtime_state, recorder.as_ref()).await;
-                let recorded = finish_capture(recorder, writer).await;
-                result?;
-                stopped?;
-                inactive?;
-                shutdown?;
-                recorded?;
-                Ok(())
+                }
             }
         };
     }
@@ -1426,6 +1441,7 @@ async fn run_capture(
         Some(profile.name().into()),
         Some(capture_subscriptions),
         runtime.clone(),
+        None,
     )
     .await
     {
@@ -1558,16 +1574,37 @@ async fn record_capture_start_failure(
     Ok(())
 }
 
-fn live_subscriptions() -> Result<Vec<Subscription>, String> {
-    [
-        ("engine.rpm", 200),
-        ("engine.maf", 500),
-        ("engine.coolant_temperature", 1_000),
-        ("vehicle.speed", 1_000),
-    ]
-    .into_iter()
-    .map(|(signal, milliseconds)| Subscription::new(signal, Duration::from_millis(milliseconds)))
-    .collect()
+fn planned_layout_subscriptions(
+    layout: &tui::DashboardLayout,
+    advertised: &[ble::SignalSupport],
+) -> Result<
+    (
+        obdentic::subscription_policy::PollingPlan,
+        Vec<Subscription>,
+    ),
+    String,
+> {
+    let supported = advertised.iter().filter_map(|signal| {
+        (signal.status == ble::SignalSupportStatus::Supported).then_some(signal.semantic)
+    });
+    let policy = layout_observation::polling_plan(
+        layout,
+        LayoutFreshnessPolicy::default(),
+        SubscriptionPolicy::new(HardwareCapability::conservative_default()),
+        supported,
+    )?;
+    let subscriptions = policy
+        .scheduled_entries()
+        .map(|entry| {
+            Subscription::new(
+                entry.semantic(),
+                entry
+                    .effective_interval()
+                    .expect("scheduled entry has an effective interval"),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((policy, subscriptions))
 }
 
 async fn routed_observation_plans(
@@ -2484,6 +2521,46 @@ mod tests {
             SubscriptionFilterOutcome::Unsupported
         );
         assert_eq!(decisions[2].filter(), SubscriptionFilterOutcome::Unknown);
+    }
+
+    #[test]
+    fn layout_planning_schedules_only_supported_semantics() {
+        let layout = tui::DashboardLayout {
+            name: "custom".into(),
+            panels: vec![
+                tui::Panel {
+                    title: "RPM".into(),
+                    view: tui::View::Value,
+                    signals: vec!["engine.rpm".into()],
+                },
+                tui::Panel {
+                    title: "Future".into(),
+                    view: tui::View::Value,
+                    signals: vec!["vehicle.future_fact".into()],
+                },
+            ],
+        };
+        let (plan, subscriptions) = planned_layout_subscriptions(
+            &layout,
+            &[ble::SignalSupport {
+                semantic: "engine.rpm",
+                status: ble::SignalSupportStatus::Supported,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(subscriptions.len(), 1);
+        assert_eq!(subscriptions[0].semantic(), "engine.rpm");
+        let future = plan
+            .entries()
+            .iter()
+            .find(|entry| entry.semantic() == "vehicle.future_fact")
+            .unwrap();
+        assert_eq!(
+            future.status(),
+            obdentic::subscription_policy::PlanStatus::Unsupported
+        );
+        assert!(future.effective_interval().is_none());
     }
 
     #[test]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -9,7 +9,7 @@ use crate::{
     runtime_actor::RuntimeClient,
     runtime_reducer::RuntimeEvent,
     runtime_state::RuntimeState,
-    subscription_policy::{ObservationRequest, SubscriptionPolicy},
+    subscription_policy::{ObservationRequest, PollingPlan, SubscriptionPolicy},
     telemetry::TelemetryState,
     vehicle_knowledge::{ReadRouting, RoutingDecision},
     ReadRequest,
@@ -162,6 +162,7 @@ pub fn is_fatal_runtime_error(error: &str) -> bool {
 }
 
 impl TelemetryScheduler {
+    #[allow(clippy::too_many_arguments)]
     pub async fn start<Plan: Into<ObservationPlan>>(
         adapter_id: &str,
         subscriptions: Vec<Plan>,
@@ -170,6 +171,7 @@ impl TelemetryScheduler {
         recorder: Option<mpsc::Sender<CaptureEvent>>,
         capture_profile: Option<String>,
         capture_subscriptions: Option<Vec<CaptureSubscription>>,
+        policy_state: Option<Arc<Mutex<PollingPlan>>>,
     ) -> Result<Self, String> {
         let (runtime, _runtime_task) = crate::runtime_actor::start();
         runtime
@@ -185,6 +187,7 @@ impl TelemetryScheduler {
             capture_profile,
             capture_subscriptions,
             runtime,
+            policy_state,
         )
         .await
     }
@@ -200,6 +203,7 @@ impl TelemetryScheduler {
         capture_profile: Option<String>,
         capture_subscriptions: Option<Vec<CaptureSubscription>>,
         runtime: RuntimeClient,
+        policy_state: Option<Arc<Mutex<PollingPlan>>>,
     ) -> Result<Self, String> {
         if subscriptions.is_empty() {
             return Err("telemetry scheduler needs at least one subscription".into());
@@ -322,6 +326,13 @@ impl TelemetryScheduler {
                 };
             }
         };
+        if let Err(error) = synchronize_policy_state(policy_state.as_ref(), &subscriptions) {
+            let cleanup = session.shutdown().await;
+            return match cleanup {
+                Ok(()) => Err(error),
+                Err(cleanup) => Err(format!("{error}; cleanup failed: {cleanup}")),
+            };
+        }
         let mut events = std::iter::once(started)
             .chain(std::iter::once(CaptureEvent::SessionInitialized))
             .chain(configured.into_iter().map(CaptureSubscription::into_event))
@@ -358,6 +369,7 @@ impl TelemetryScheduler {
             cancelled,
             runtime,
             runtime_state,
+            policy_state,
         ));
         Ok(Self { cancel, task })
     }
@@ -385,6 +397,7 @@ async fn run(
     mut cancelled: oneshot::Receiver<()>,
     runtime: RuntimeClient,
     mut runtime_state: RuntimeState,
+    policy_state: Option<Arc<Mutex<PollingPlan>>>,
 ) -> Result<(), String> {
     let mut schedule = subscriptions
         .into_iter()
@@ -618,7 +631,12 @@ async fn run(
                     Ok(capability) => capability,
                     Err(error) => break 'scheduler Err(error),
                 };
-                if let Err(error) = reshape_schedule(&mut schedule, capability, Instant::now()) {
+                if let Err(error) = reshape_schedule(
+                    &mut schedule,
+                    capability,
+                    Instant::now(),
+                    policy_state.as_ref(),
+                ) {
                     break 'scheduler Err(error);
                 }
             }
@@ -728,6 +746,7 @@ fn reshape_schedule(
     schedule: &mut [(ObservationPlan, Instant)],
     capability: HardwareCapability,
     now: Instant,
+    policy_state: Option<&Arc<Mutex<PollingPlan>>>,
 ) -> Result<(), String> {
     let plans = schedule
         .iter()
@@ -740,7 +759,25 @@ fn reshape_schedule(
         }
         *plan = replacement;
     }
+    let current = schedule
+        .iter()
+        .map(|(plan, _)| plan.clone())
+        .collect::<Vec<_>>();
+    synchronize_policy_state(policy_state, &current)?;
     Ok(())
+}
+
+fn synchronize_policy_state(
+    policy_state: Option<&Arc<Mutex<PollingPlan>>>,
+    plans: &[ObservationPlan],
+) -> Result<(), String> {
+    let Some(policy_state) = policy_state else {
+        return Ok(());
+    };
+    let mut policy = policy_state
+        .lock()
+        .map_err(|_| "polling policy state lock poisoned".to_string())?;
+    policy.update_effective_intervals(plans.iter().map(|plan| (plan.semantic(), plan.interval())))
 }
 
 fn offset_us(origin: Instant, at: Instant) -> CaptureTimeUs {
@@ -943,6 +980,46 @@ mod tests {
         assert!(matches!(reshaped[1].routing(), ReadRouting::Functional(_)));
         assert!(reshaped[0].interval() > targeted.interval());
         assert!(reshaped[1].interval() > functional.interval());
+    }
+
+    #[test]
+    fn policy_state_sync_tracks_actual_observation_intervals() {
+        let policy = SubscriptionPolicy::new(
+            HardwareCapability::new(
+                4,
+                Duration::from_millis(250),
+                crate::capability::CapabilityProvenance::BuiltInDefault,
+            )
+            .unwrap(),
+        );
+        let plan = policy.plan(
+            [
+                ObservationRequest::new("layout:test", "engine.rpm", Duration::from_millis(100))
+                    .unwrap(),
+            ],
+            ["engine.rpm"],
+        );
+        let shared = Arc::new(Mutex::new(plan));
+        let observation = ObservationPlan::new(
+            ReadRouting::Functional(crate::prepare_read("engine.rpm").unwrap()),
+            Duration::from_millis(500),
+        )
+        .unwrap();
+
+        synchronize_policy_state(Some(&shared), &[observation]).unwrap();
+
+        let plan = shared.lock().unwrap();
+        let entry = &plan.entries()[0];
+        assert_eq!(entry.requested_interval(), Duration::from_millis(100));
+        assert_eq!(entry.effective_interval(), Some(Duration::from_millis(500)));
+        assert_eq!(
+            entry.status(),
+            crate::subscription_policy::PlanStatus::RateReduced
+        );
+        assert_eq!(
+            entry.reason(),
+            crate::subscription_policy::PlanReason::SessionRequestBudget
+        );
     }
 
     #[test]

--- a/src/subscription_policy.rs
+++ b/src/subscription_policy.rs
@@ -127,6 +127,63 @@ impl PollingPlan {
             .map(|interval| 1.0 / interval.as_secs_f64())
             .sum()
     }
+
+    /// Replace effective intervals with the intervals chosen by the runtime
+    /// scheduler while preserving the original requests.
+    pub fn update_effective_intervals<I, Name>(&mut self, intervals: I) -> Result<(), String>
+    where
+        I: IntoIterator<Item = (Name, Duration)>,
+        Name: AsRef<str>,
+    {
+        let mut updates = BTreeMap::new();
+        for (semantic, interval) in intervals {
+            if interval.is_zero() {
+                return Err("effective polling interval must be greater than zero".into());
+            }
+            let semantic = semantic.as_ref().to_owned();
+            if updates.insert(semantic.clone(), interval).is_some() {
+                return Err(format!(
+                    "duplicate effective polling interval for {semantic}"
+                ));
+            }
+        }
+
+        for entry in &self.entries {
+            if entry.status != PlanStatus::Unsupported && !updates.contains_key(&entry.semantic) {
+                return Err(format!(
+                    "missing effective polling interval for {}",
+                    entry.semantic
+                ));
+            }
+        }
+        for semantic in updates.keys() {
+            if !self.entries.iter().any(|entry| &entry.semantic == semantic) {
+                return Err(format!("unknown effective polling semantic {semantic}"));
+            }
+        }
+
+        for entry in &mut self.entries {
+            let Some(&effective_interval) = updates.get(&entry.semantic) else {
+                continue;
+            };
+            if entry.status == PlanStatus::Unsupported {
+                continue;
+            }
+            let reduced = effective_interval > entry.requested_interval;
+            entry.effective_interval = Some(effective_interval);
+            entry.status = if reduced {
+                PlanStatus::RateReduced
+            } else {
+                PlanStatus::Accepted
+            };
+            entry.reason = if reduced {
+                PlanReason::SessionRequestBudget
+            } else {
+                PlanReason::WithinBudget
+            };
+        }
+        Ok(())
+    }
 }
 
 /// Deterministic policy that translates semantic demand into a bounded plan.
@@ -425,5 +482,60 @@ mod tests {
         );
 
         assert!(plan.effective_request_rate_per_second() <= 5.0);
+    }
+
+    #[test]
+    fn runtime_intervals_refresh_status_without_changing_requests() {
+        let mut plan = policy(4).plan(
+            [
+                request("tui", "engine.rpm", 100),
+                request("tui", "engine.maf", 200),
+                request("tui", "vehicle.future", 500),
+            ],
+            ["engine.rpm", "engine.maf"],
+        );
+
+        plan.update_effective_intervals([
+            ("engine.rpm", Duration::from_millis(500)),
+            ("engine.maf", Duration::from_millis(100)),
+        ])
+        .unwrap();
+
+        let rpm = plan
+            .entries()
+            .iter()
+            .find(|entry| entry.semantic() == "engine.rpm")
+            .unwrap();
+        assert_eq!(rpm.requested_interval(), Duration::from_millis(100));
+        assert_eq!(rpm.effective_interval(), Some(Duration::from_millis(500)));
+        assert_eq!(rpm.status(), PlanStatus::RateReduced);
+        assert_eq!(rpm.reason(), PlanReason::SessionRequestBudget);
+        let maf = plan
+            .entries()
+            .iter()
+            .find(|entry| entry.semantic() == "engine.maf")
+            .unwrap();
+        assert_eq!(maf.requested_interval(), Duration::from_millis(200));
+        assert_eq!(maf.effective_interval(), Some(Duration::from_millis(100)));
+        assert_eq!(maf.status(), PlanStatus::Accepted);
+        assert_eq!(maf.reason(), PlanReason::WithinBudget);
+        let future = plan
+            .entries()
+            .iter()
+            .find(|entry| entry.semantic() == "vehicle.future")
+            .unwrap();
+        assert_eq!(future.status(), PlanStatus::Unsupported);
+        assert_eq!(future.effective_interval(), None);
+    }
+
+    #[test]
+    fn runtime_interval_update_is_validated_before_mutation() {
+        let mut plan = policy(4).plan([request("tui", "engine.rpm", 100)], ["engine.rpm"]);
+        let original = plan.clone();
+
+        assert!(plan
+            .update_effective_intervals([("engine.unknown", Duration::from_millis(100))])
+            .is_err());
+        assert_eq!(plan, original);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,7 @@
 use crate::{
     audit::{AuditEntry, AuditState},
     hex,
+    subscription_policy::{PlanReason, PlanStatus, PollingPlan},
     telemetry::{Sample, TelemetryState},
     Transaction,
 };
@@ -263,6 +264,7 @@ pub fn run_live(
     layout: &DashboardLayout,
     telemetry: Arc<Mutex<TelemetryState>>,
     audit: Arc<Mutex<AuditState>>,
+    policy_state: Arc<Mutex<PollingPlan>>,
 ) -> Result<(), String> {
     enable_raw_mode().map_err(|error| error.to_string())?;
     let mut stdout = io::stdout();
@@ -281,8 +283,12 @@ pub fn run_live(
             .lock()
             .map_err(|_| "audit state lock poisoned")?
             .snapshot();
+        let plan = policy_state
+            .lock()
+            .map_err(|_| "polling policy state lock poisoned")?
+            .clone();
         terminal
-            .draw(|frame| render(frame, layout, &state, &audit))
+            .draw(|frame| render_live(frame, layout, &state, &audit, &plan))
             .map_err(|error| error.to_string())?;
         if event::poll(Duration::from_millis(100)).map_err(|error| error.to_string())?
             && matches!(event::read().map_err(|error| error.to_string())?, Event::Key(key) if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc))
@@ -321,12 +327,35 @@ fn render(
     state: &TelemetryState,
     audit: &[AuditEntry],
 ) {
-    let areas = Layout::vertical([
-        Constraint::Length(3),
-        Constraint::Min(15),
-        Constraint::Length(6),
-    ])
-    .split(frame.area());
+    render_with_policy(frame, layout, state, audit, None);
+}
+
+fn render_live(
+    frame: &mut Frame,
+    layout: &DashboardLayout,
+    state: &TelemetryState,
+    audit: &[AuditEntry],
+    plan: &PollingPlan,
+) {
+    render_with_policy(frame, layout, state, audit, Some(plan));
+}
+
+fn render_with_policy(
+    frame: &mut Frame,
+    layout: &DashboardLayout,
+    state: &TelemetryState,
+    audit: &[AuditEntry],
+    plan: Option<&PollingPlan>,
+) {
+    let mut constraints = vec![Constraint::Length(3)];
+    if let Some(plan) = plan {
+        let policy_height = u16::try_from(plan.entries().len())
+            .unwrap_or(u16::MAX)
+            .saturating_add(2);
+        constraints.push(Constraint::Length(policy_height));
+    }
+    constraints.extend([Constraint::Min(15), Constraint::Length(6)]);
+    let areas = Layout::vertical(constraints).split(frame.area());
     let source = audit
         .first()
         .map(|entry| entry.source.as_str())
@@ -340,9 +369,14 @@ fn render(
         areas[0],
     );
 
-    render_panels(frame, areas[1], layout, state);
+    let mut content_index = 1;
+    if let Some(plan) = plan {
+        render_policy(frame, areas[content_index], plan);
+        content_index += 1;
+    }
+    render_panels(frame, areas[content_index], layout, state);
     let bottom = Layout::horizontal([Constraint::Percentage(65), Constraint::Percentage(35)])
-        .split(areas[2]);
+        .split(areas[content_index + 1]);
     let raw = audit.iter().map(|entry| {
         ListItem::new(format!(
             "{}  TX {}  RX {}",
@@ -362,6 +396,55 @@ fn render(
         List::new(activity).block(Block::default().borders(Borders::ALL).title("Activity")),
         bottom[1],
     );
+}
+
+fn render_policy(frame: &mut Frame, area: Rect, plan: &PollingPlan) {
+    let entries = plan.entries().iter().map(|entry| {
+        ListItem::new(format!(
+            "{}  requested={}  effective={}  status={}  reason={}",
+            entry.semantic(),
+            format_interval(entry.requested_interval()),
+            entry
+                .effective_interval()
+                .map(format_interval)
+                .unwrap_or_else(|| "not scheduled".into()),
+            plan_status(entry.status()),
+            plan_reason(entry.reason()),
+        ))
+    });
+    frame.render_widget(
+        List::new(entries).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Observation policy"),
+        ),
+        area,
+    );
+}
+
+fn format_interval(interval: Duration) -> String {
+    let milliseconds = interval.as_millis();
+    if milliseconds > 0 {
+        format!("{milliseconds} ms")
+    } else {
+        format!("{} us", interval.as_micros())
+    }
+}
+
+fn plan_status(status: PlanStatus) -> &'static str {
+    match status {
+        PlanStatus::Accepted => "accepted",
+        PlanStatus::RateReduced => "budget-limited/rate-reduced",
+        PlanStatus::Unsupported => "unsupported",
+    }
+}
+
+fn plan_reason(reason: PlanReason) -> &'static str {
+    match reason {
+        PlanReason::WithinBudget => "within budget",
+        PlanReason::SessionRequestBudget => "session request budget",
+        PlanReason::SignalUnsupported => "signal unsupported",
+    }
 }
 
 fn render_panels(frame: &mut Frame, area: Rect, layout: &DashboardLayout, state: &TelemetryState) {
@@ -622,7 +705,12 @@ fn chart_bounds(left: &[(f64, f64)], right: &[(f64, f64)]) -> (f64, f64, f64, f6
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{prepare_read, telemetry::TelemetryState};
+    use crate::{
+        capability::{CapabilityProvenance, HardwareCapability},
+        prepare_read,
+        subscription_policy::{ObservationRequest, SubscriptionPolicy},
+        telemetry::TelemetryState,
+    };
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
@@ -671,6 +759,27 @@ mod tests {
             .collect()
     }
 
+    fn policy(requests_per_second: u32) -> SubscriptionPolicy {
+        SubscriptionPolicy::new(
+            HardwareCapability::new(
+                requests_per_second,
+                Duration::from_millis(250),
+                CapabilityProvenance::BuiltInDefault,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
     #[test]
     fn renders_decoded_samples_without_requesting_transport() {
         let transaction = prepare_read("engine.rpm")
@@ -691,13 +800,7 @@ mod tests {
         terminal
             .draw(|frame| render(frame, &layout, &state, &audit))
             .unwrap();
-        let text: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect();
+        let text = buffer_text(&terminal);
         assert!(text.contains("Engine RPM"));
         assert!(text.contains("01 0C"));
         assert!(text.contains("1726.00 rpm"));
@@ -823,13 +926,7 @@ mod tests {
         terminal
             .draw(|frame| render(frame, &layout, &state, &audit))
             .unwrap();
-        let text: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect();
+        let text = buffer_text(&terminal);
         for title in [
             "Custom value",
             "Custom sparkline",
@@ -881,13 +978,62 @@ mod tests {
         terminal
             .draw(|frame| render(frame, &layout, &state, &audit))
             .unwrap();
-        let text: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect();
+        let text = buffer_text(&terminal);
         assert!(text.contains("unsupported: future.signal"));
+    }
+
+    #[test]
+    fn renders_live_policy_status_and_requested_effective_intervals() {
+        let requests = [
+            ObservationRequest::new("layout:test", "engine.rpm", Duration::from_secs(1)).unwrap(),
+            ObservationRequest::new("layout:test", "future.signal", Duration::from_secs(1))
+                .unwrap(),
+        ];
+        let plan = policy(4).plan(&requests, ["engine.rpm"]);
+        let mut terminal = Terminal::new(TestBackend::new(140, 32)).unwrap();
+        terminal
+            .draw(|frame| {
+                render_live(
+                    frame,
+                    &engine_overview(),
+                    &TelemetryState::new(1).unwrap(),
+                    &[],
+                    &plan,
+                )
+            })
+            .unwrap();
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Observation policy"));
+        assert!(text.contains(
+            "engine.rpm  requested=1000 ms  effective=1000 ms  status=accepted  reason=within budget"
+        ));
+        assert!(text.contains(
+            "future.signal  requested=1000 ms  effective=not scheduled  status=unsupported  reason=signal unsupported"
+        ));
+    }
+
+    #[test]
+    fn renders_rate_reduced_policy_as_budget_limited() {
+        let request =
+            ObservationRequest::new("layout:test", "engine.rpm", Duration::from_millis(100))
+                .unwrap();
+        let plan = policy(1).plan([request], ["engine.rpm"]);
+        let mut terminal = Terminal::new(TestBackend::new(140, 32)).unwrap();
+        terminal
+            .draw(|frame| {
+                render_live(
+                    frame,
+                    &engine_overview(),
+                    &TelemetryState::new(1).unwrap(),
+                    &[],
+                    &plan,
+                )
+            })
+            .unwrap();
+        let text = buffer_text(&terminal);
+        assert!(text.contains("requested=100 ms"));
+        assert!(text.contains("effective=1000 ms"));
+        assert!(text.contains("status=budget-limited/rate-reduced"));
+        assert!(text.contains("reason=session request budget"));
     }
 }


### PR DESCRIPTION
Closes #18.

- Derive semantic observation requests from persisted layouts without adding protocol or polling fields to layout files.
- Plan only advertised supported signals through the existing capability policy; scheduler reshapes are reflected in the live policy state.
- Show requested/effective intervals, status, and reason in live TUI; offline capture rendering remains passive.

Checks: cargo fmt --check, cargo test --locked, cargo clippy --all-targets --locked -- -D warnings, cargo build --locked.