### PR TITLE
Add EA189 DPF evidence probe

### DIFF
--- a/src/ble.rs
+++ b/src/ble.rs
@@ -1,8 +1,10 @@
 use crate::{
     capability::{CapabilityProvenance, HardwareCapability},
+    ea189::Ea189DpfProbe,
     topology::AddressingContext,
     topology::Protocol,
     topology::RequestTarget,
+    vehicle_knowledge::EcuTargetMapping,
     ReadRequest, Transaction,
 };
 use btleplug::{
@@ -114,6 +116,14 @@ impl PreparedDiagnosticSession {
         &self.negotiation
     }
 
+    /// Execute one closed EA189 candidate probe while retaining this session.
+    pub async fn read_dpf_probe(
+        &self,
+        request: TargetedDpfProbeRequest,
+    ) -> Result<DiagnosticResponses, String> {
+        self.session.read_dpf_probe(request).await
+    }
+
     /// Execute the one bounded stored-DTC request and deterministically close
     /// the physical session afterwards.
     pub async fn read_stored_dtcs(self) -> Result<DiagnosticResponses, String> {
@@ -167,6 +177,70 @@ impl TargetedReadRequest {
 
     pub fn request(&self) -> ReadRequest {
         self.request
+    }
+
+    pub fn target(&self) -> &RequestTarget {
+        &self.target
+    }
+
+    pub fn expected_responder(&self) -> &ResponderIdentity {
+        &self.expected_responder
+    }
+}
+
+/// The sole live UDS request admitted by the transport.  The profile owns
+/// the DID; callers cannot construct a generic UDS request or inject bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetedDpfProbeRequest {
+    operation: crate::protocol::ReadOperation,
+    target: RequestTarget,
+    expected_responder: ResponderIdentity,
+}
+
+impl TargetedDpfProbeRequest {
+    /// Construct a closed EA189 probe from independently validated engine
+    /// routing evidence. The profile fixes the DID; callers provide no bytes.
+    pub fn from_mapping(probe: Ea189DpfProbe, mapping: &EcuTargetMapping) -> Result<Self, String> {
+        if mapping.role().role() != &crate::topology::EcuRole::Engine {
+            return Err("EA189 DPF probes require validated engine target evidence".into());
+        }
+        let target = mapping.target().target().clone();
+        if mapping.expected_responder().context() != target.context() {
+            return Err("EA189 DPF probe target and responder contexts differ".into());
+        }
+        let expected_responder = mapping
+            .expected_responder()
+            .value()
+            .ok_or_else(|| "EA189 DPF probes require an expected responder".to_string())?;
+        Self::new(
+            probe,
+            target,
+            ResponderIdentity::ElmHeader(expected_responder.to_owned()),
+        )
+    }
+
+    fn new(
+        probe: Ea189DpfProbe,
+        target: RequestTarget,
+        expected_responder: ResponderIdentity,
+    ) -> Result<Self, String> {
+        validate_request_target(&target)?;
+        validate_elm_header(&expected_responder, "expected responder")?;
+        Ok(Self {
+            operation: crate::protocol::ReadOperation::uds_read_data_by_identifier(probe.id()),
+            target,
+            expected_responder: ResponderIdentity::ElmHeader(
+                expected_responder.as_str().to_ascii_uppercase(),
+            ),
+        })
+    }
+
+    pub fn did(&self) -> u16 {
+        self.operation.did()
+    }
+
+    pub fn request_bytes(&self) -> [u8; 3] {
+        self.operation.request_bytes()
     }
 
     pub fn target(&self) -> &RequestTarget {
@@ -259,6 +333,27 @@ impl ReadOutcome {
     fn into_transaction(self) -> Result<Transaction, String> {
         match self {
             Self::Succeeded { transaction, .. } => Ok(transaction),
+            Self::Failed { error, .. } => Err(error),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum DpfProbeOutcome {
+    Succeeded {
+        responses: DiagnosticResponses,
+        observations: Vec<ResponseObservation>,
+    },
+    Failed {
+        error: String,
+        observations: Vec<ResponseObservation>,
+    },
+}
+
+impl DpfProbeOutcome {
+    fn into_result(self) -> Result<DiagnosticResponses, String> {
+        match self {
+            Self::Succeeded { responses, .. } => Ok(responses),
             Self::Failed { error, .. } => Err(error),
         }
     }
@@ -583,6 +678,32 @@ impl SessionClient {
             .into_transaction()
     }
 
+    /// Execute the closed EA189 DPF UDS probe and return its raw normalized
+    /// responses.  Negative or malformed responses are returned as errors,
+    /// while the crate-visible evidence variant retains responder payloads.
+    pub async fn read_dpf_probe(
+        &self,
+        request: TargetedDpfProbeRequest,
+    ) -> Result<DiagnosticResponses, String> {
+        self.read_dpf_probe_with_evidence(request)
+            .await?
+            .into_result()
+    }
+
+    pub(crate) async fn read_dpf_probe_with_evidence(
+        &self,
+        request: TargetedDpfProbeRequest,
+    ) -> Result<DpfProbeOutcome, String> {
+        let (reply, result) = oneshot::channel();
+        self.sender
+            .send(SessionCommand::ReadDpfProbe { request, reply })
+            .await
+            .map_err(|_| "diagnostic session is closed".to_string())?;
+        result
+            .await
+            .map_err(|_| "diagnostic session stopped before responding".to_string())?
+    }
+
     pub async fn read_stored_dtcs(&self) -> Result<DiagnosticResponses, String> {
         let (reply, result) = oneshot::channel();
         self.sender
@@ -639,6 +760,10 @@ enum SessionCommand {
     ReadTargeted {
         request: TargetedReadRequest,
         reply: oneshot::Sender<Result<ReadOutcome, String>>,
+    },
+    ReadDpfProbe {
+        request: TargetedDpfProbeRequest,
+        reply: oneshot::Sender<Result<DpfProbeOutcome, String>>,
     },
     ReadStoredDtcs {
         reply: oneshot::Sender<Result<DiagnosticResponses, String>>,
@@ -738,6 +863,24 @@ async fn session_actor(
                 )
                 .await;
             }
+            SessionCommand::ReadDpfProbe { request, reply } => {
+                if let Some(error) = health.unhealthy() {
+                    let _ = reply.send(Err(error.to_owned()));
+                    continue;
+                }
+                let started = Instant::now();
+                let outcome = session.read_dpf_probe_with_evidence(request).await;
+                process_dpf_probe_outcome(
+                    &mut session,
+                    &mut health,
+                    &mut service,
+                    &mut disconnect_done,
+                    outcome,
+                    started.elapsed(),
+                    reply,
+                )
+                .await;
+            }
             SessionCommand::ReadStoredDtcs { reply } => {
                 if let Some(error) = health.unhealthy() {
                     let _ = reply.send(Err(error.to_owned()));
@@ -817,6 +960,48 @@ async fn process_read_outcome(
             } else {
                 service.observe(service_time);
                 let _ = reply.send(Ok(ReadOutcome::Failed {
+                    error,
+                    observations,
+                }));
+            }
+        }
+    }
+}
+
+async fn process_dpf_probe_outcome(
+    session: &mut DiagnosticSession,
+    health: &mut SessionHealth,
+    service: &mut RequestServiceEstimator,
+    disconnect_done: &mut bool,
+    outcome: DpfProbeOutcome,
+    service_time: Duration,
+    reply: oneshot::Sender<Result<DpfProbeOutcome, String>>,
+) {
+    if let Some(error) = health.unhealthy() {
+        let _ = reply.send(Err(error.to_owned()));
+        return;
+    }
+    match outcome {
+        DpfProbeOutcome::Succeeded { .. } => {
+            service.observe(service_time);
+            health.success();
+            let _ = reply.send(Ok(outcome));
+        }
+        DpfProbeOutcome::Failed {
+            error,
+            observations,
+        } => {
+            if health.observe(&error) {
+                let fatal = health.unhealthy().unwrap().to_owned();
+                session.disconnect_best_effort().await;
+                *disconnect_done = true;
+                let _ = reply.send(Ok(DpfProbeOutcome::Failed {
+                    error: fatal,
+                    observations,
+                }));
+            } else {
+                service.observe(service_time);
+                let _ = reply.send(Ok(DpfProbeOutcome::Failed {
                     error,
                     observations,
                 }));
@@ -964,6 +1149,31 @@ impl DiagnosticSession {
         self.read_targeted_with_evidence(request)
             .await
             .into_transaction()
+    }
+
+    async fn read_dpf_probe_with_evidence(
+        &mut self,
+        request: TargetedDpfProbeRequest,
+    ) -> DpfProbeOutcome {
+        let read = {
+            let mut exchange = LiveExchange {
+                peripheral: &self.peripheral,
+                channel: &self.channel,
+                notifications: &mut self.notifications,
+                show_adapter_io: self.show_adapter_io,
+            };
+            read_elm_dpf_probe_with_evidence(&mut exchange, &request).await
+        };
+        match read {
+            Ok(read) => DpfProbeOutcome::Succeeded {
+                responses: read.responses,
+                observations: read.observations,
+            },
+            Err(error) => DpfProbeOutcome::Failed {
+                error: error.error,
+                observations: error.observations,
+            },
+        }
     }
 
     async fn read_stored_dtcs(&mut self) -> Result<DiagnosticResponses, String> {
@@ -1408,7 +1618,9 @@ async fn read_elm_targeted_with_evidence<E>(
 where
     E: ElmExchange,
 {
-    if let Err(error) = configure_target(exchange, request).await {
+    if let Err(error) =
+        configure_target(exchange, request.target(), request.expected_responder()).await
+    {
         let restore = restore_functional(exchange).await;
         return Err(ReadEvidenceError {
             error: combine_setup_errors(error, restore),
@@ -1452,16 +1664,61 @@ where
     }
 }
 
-async fn configure_target<E>(exchange: &mut E, request: &TargetedReadRequest) -> Result<(), String>
+#[derive(Debug)]
+struct DpfProbeReadEvidence {
+    responses: DiagnosticResponses,
+    observations: Vec<ResponseObservation>,
+}
+
+async fn read_elm_dpf_probe_with_evidence<E>(
+    exchange: &mut E,
+    request: &TargetedDpfProbeRequest,
+) -> Result<DpfProbeReadEvidence, ReadEvidenceError>
 where
     E: ElmExchange,
 {
-    let address = request
-        .target()
+    if let Err(error) = configure_dpf_probe_target(exchange, request).await {
+        return Err(ReadEvidenceError {
+            error,
+            observations: Vec::new(),
+        });
+    }
+
+    match read_elm_uds_responses(exchange, request).await {
+        Ok(responses) => Ok(DpfProbeReadEvidence {
+            observations: vec![responses.observation(None)],
+            responses,
+        }),
+        Err(error) => Err(ReadEvidenceError {
+            error,
+            observations: Vec::new(),
+        }),
+    }
+}
+
+async fn configure_dpf_probe_target<E>(
+    exchange: &mut E,
+    request: &TargetedDpfProbeRequest,
+) -> Result<(), String>
+where
+    E: ElmExchange,
+{
+    configure_target(exchange, request.target(), request.expected_responder()).await
+}
+
+async fn configure_target<E>(
+    exchange: &mut E,
+    target: &RequestTarget,
+    expected_responder: &ResponderIdentity,
+) -> Result<(), String>
+where
+    E: ElmExchange,
+{
+    let address = target
         .address()
         .expect("validated targeted request has a concrete address");
     let target_header = address.value().to_ascii_uppercase();
-    let expected_header = request.expected_responder().as_str();
+    let expected_header = expected_responder.as_str();
     for (command, error) in [
         (
             format!("ATSH {target_header}\r"),
@@ -1533,6 +1790,19 @@ where
     normalize_mode01_responses(&response, request.pid(), request.data_len())
 }
 
+async fn read_elm_uds_responses<E>(
+    exchange: &mut E,
+    request: &TargetedDpfProbeRequest,
+) -> Result<DiagnosticResponses, String>
+where
+    E: ElmExchange,
+{
+    let operation = request.operation;
+    let command = uds_command(operation);
+    let response = exchange.exchange(&command, COMMAND_TIMEOUT).await?;
+    normalize_uds_responses(&response, operation.did())
+}
+
 pub(crate) async fn read_elm_mode03_responses<E>(
     exchange: &mut E,
 ) -> Result<DiagnosticResponses, String>
@@ -1564,6 +1834,7 @@ async fn elm_exchange<S>(
 where
     S: Stream<Item = ValueNotification> + Unpin,
 {
+    discard_queued_notifications(notifications).await;
     let write_type = if channel
         .properties
         .contains(CharPropFlags::WRITE_WITHOUT_RESPONSE)
@@ -1590,6 +1861,19 @@ where
         println!("{line}");
     }
     Ok(response)
+}
+
+/// A Carly adapter can deliver a fragment just after the prompt that closed
+/// the preceding exchange. It cannot belong to the next command, so discard
+/// queued notifications before writing that command.
+async fn discard_queued_notifications<S>(notifications: &mut S)
+where
+    S: Stream<Item = ValueNotification> + Unpin,
+{
+    while matches!(
+        timeout(Duration::from_millis(2), notifications.next()).await,
+        Ok(Some(_))
+    ) {}
 }
 
 fn adapter_io_line(
@@ -1637,6 +1921,11 @@ fn obd_command(request: ReadRequest) -> String {
     }
     command.push('\r');
     command
+}
+
+fn uds_command(operation: crate::protocol::ReadOperation) -> String {
+    let [service, high, low] = operation.request_bytes();
+    format!("{service:02X}{high:02X}{low:02X}\r")
 }
 
 fn require_response(
@@ -2301,6 +2590,287 @@ fn mode01_responses(
         .ok_or_else(|| format!("01{pid:02X} response not found in {response:?}"))
 }
 
+#[derive(Debug)]
+struct UdsIsoTpAssembly {
+    declared_len: usize,
+    payload: Vec<u8>,
+    next_sequence: u8,
+}
+
+fn push_uds_payload(
+    matches: &mut Vec<DiagnosticResponse>,
+    responder: Option<ResponderIdentity>,
+    payload: &[u8],
+) {
+    if !payload.is_empty() {
+        matches.push(DiagnosticResponse {
+            responder,
+            payload: payload.to_vec(),
+        });
+    }
+}
+
+/// Normalize one ELM response to UDS application payloads while retaining
+/// every responder and the complete raw adapter text in `DiagnosticResponses`.
+fn normalize_uds_responses(response: &str, did: u16) -> Result<DiagnosticResponses, String> {
+    let mut matches = Vec::new();
+    let mut errors = Vec::new();
+    let mut assemblies: Vec<(Option<ResponderIdentity>, UdsIsoTpAssembly)> = Vec::new();
+    let request_echo = format!("22{did:04X}");
+
+    for raw_line in response.split(['\r', '\n']) {
+        let line = raw_line.trim().trim_end_matches('>').trim();
+        if line.is_empty() {
+            continue;
+        }
+        let upper = line.to_ascii_uppercase();
+        let compact = upper.split_ascii_whitespace().collect::<String>();
+        if compact == request_echo
+            || upper.starts_with("SEARCHING")
+            || (upper.starts_with("BUS INIT") && !upper.contains("ERROR"))
+        {
+            continue;
+        }
+        if ["?", "NO DATA", "STOPPED", "UNABLE TO CONNECT", "ERROR"]
+            .iter()
+            .any(|status| upper == *status || upper.contains(status))
+        {
+            errors.push(DiagnosticResponseError {
+                responder: None,
+                error: format!("ELM327 rejected UDS 22 response: {line}"),
+            });
+            continue;
+        }
+
+        let tokens = line.split_ascii_whitespace().collect::<Vec<_>>();
+        let header = tokens.first().filter(|token| token.len() == 3).copied();
+        let responder = if let Some(header) = header {
+            if !header.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                errors.push(DiagnosticResponseError {
+                    responder: None,
+                    error: format!("malformed ELM327 UDS responder header: {line:?}"),
+                });
+                continue;
+            }
+            Some(ResponderIdentity::ElmHeader(header.to_ascii_uppercase()))
+        } else {
+            None
+        };
+        let data = if header.is_some() {
+            &tokens[1..]
+        } else {
+            tokens.as_slice()
+        };
+        let mut bytes = Vec::new();
+        let mut malformed = None;
+        for token in data {
+            if token.is_empty()
+                || token.len() % 2 != 0
+                || !token.bytes().all(|byte| byte.is_ascii_hexdigit())
+            {
+                malformed = Some(format!("malformed ELM327 UDS response line: {line:?}"));
+                break;
+            }
+            for pair in token.as_bytes().as_chunks::<2>().0 {
+                let pair = match std::str::from_utf8(pair) {
+                    Ok(pair) => pair,
+                    Err(error) => {
+                        malformed = Some(error.to_string());
+                        break;
+                    }
+                };
+                match u8::from_str_radix(pair, 16) {
+                    Ok(byte) => bytes.push(byte),
+                    Err(error) => {
+                        malformed = Some(error.to_string());
+                        break;
+                    }
+                }
+            }
+            if malformed.is_some() {
+                break;
+            }
+        }
+        if let Some(error) = malformed {
+            errors.push(DiagnosticResponseError { responder, error });
+            continue;
+        }
+
+        match bytes.first().map(|byte| byte >> 4) {
+            Some(0) => {
+                let declared_len = (bytes[0] & 0x0f) as usize;
+                let payload = &bytes[1..];
+                if declared_len == 0 {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("malformed UDS single frame: {line:?}"),
+                    });
+                    continue;
+                }
+                if payload.len() < declared_len {
+                    push_uds_payload(&mut matches, responder.clone(), payload);
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!(
+                            "truncated UDS single frame: declared {declared_len} bytes, received {}",
+                            payload.len()
+                        ),
+                    });
+                    continue;
+                }
+                if payload[declared_len..]
+                    .iter()
+                    .any(|byte| !matches!(byte, 0x00 | 0x55 | 0xaa))
+                {
+                    push_uds_payload(&mut matches, responder.clone(), &payload[..declared_len]);
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("unexpected bytes after UDS single frame: {line:?}"),
+                    });
+                    continue;
+                }
+                push_uds_payload(&mut matches, responder, &payload[..declared_len]);
+            }
+            Some(1) => {
+                if bytes.len() < 3 {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("malformed UDS first frame: {line:?}"),
+                    });
+                    continue;
+                }
+                let declared_len = (((bytes[0] & 0x0f) as usize) << 8) | bytes[1] as usize;
+                let payload = &bytes[2..];
+                if declared_len < 3 || payload.len() >= declared_len {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!(
+                            "malformed UDS first frame: declared {declared_len} bytes, received {}",
+                            payload.len()
+                        ),
+                    });
+                    continue;
+                }
+                if assemblies
+                    .iter()
+                    .any(|(identity, _)| *identity == responder)
+                {
+                    assemblies.retain(|(identity, _)| *identity != responder);
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("duplicate UDS first frame: {line:?}"),
+                    });
+                    continue;
+                }
+                assemblies.push((
+                    responder,
+                    UdsIsoTpAssembly {
+                        declared_len,
+                        payload: payload.to_vec(),
+                        next_sequence: 1,
+                    },
+                ));
+            }
+            Some(2) => {
+                let Some(index) = assemblies
+                    .iter()
+                    .position(|(identity, _)| *identity == responder)
+                else {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("UDS consecutive frame without first frame: {line:?}"),
+                    });
+                    continue;
+                };
+                if bytes.len() < 2 {
+                    assemblies.remove(index);
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("malformed UDS consecutive frame: {line:?}"),
+                    });
+                    continue;
+                }
+                let sequence = bytes[0] & 0x0f;
+                let expected = assemblies[index].1.next_sequence;
+                if sequence != expected {
+                    assemblies.remove(index);
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!(
+                            "UDS sequence mismatch: expected {expected}, got {sequence}"
+                        ),
+                    });
+                    continue;
+                }
+                let data = &bytes[1..];
+                let (declared_len, received_len) = {
+                    let assembly = &assemblies[index].1;
+                    (assembly.declared_len, assembly.payload.len())
+                };
+                if received_len >= declared_len {
+                    assemblies.remove(index);
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("UDS payload exceeded declared length: {line:?}"),
+                    });
+                    continue;
+                }
+                let remaining = declared_len - received_len;
+                if data.len() > remaining
+                    && data[remaining..]
+                        .iter()
+                        .any(|byte| !matches!(byte, 0x00 | 0x55 | 0xaa))
+                {
+                    assemblies.remove(index);
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("UDS payload exceeded declared length: {line:?}"),
+                    });
+                    continue;
+                }
+                let complete = {
+                    let assembly = &mut assemblies[index].1;
+                    assembly
+                        .payload
+                        .extend_from_slice(&data[..data.len().min(remaining)]);
+                    assembly.next_sequence = (sequence + 1) & 0x0f;
+                    assembly.payload.len() == declared_len
+                };
+                if complete {
+                    let (_, assembly) = assemblies.remove(index);
+                    push_uds_payload(&mut matches, responder, &assembly.payload);
+                }
+            }
+            Some(3) => {
+                errors.push(DiagnosticResponseError {
+                    responder,
+                    error: format!("unexpected UDS flow-control frame: {line:?}"),
+                });
+            }
+            _ => push_uds_payload(&mut matches, responder, &bytes),
+        }
+    }
+
+    for (responder, assembly) in assemblies {
+        push_uds_payload(&mut matches, responder.clone(), &assembly.payload);
+        errors.push(DiagnosticResponseError {
+            responder,
+            error: format!(
+                "truncated UDS ISO-TP response: declared {} bytes, received {}",
+                assembly.declared_len,
+                assembly.payload.len()
+            ),
+        });
+    }
+    if matches.is_empty() && errors.is_empty() {
+        errors.push(DiagnosticResponseError {
+            responder: None,
+            error: "UDS 22 response not found".into(),
+        });
+    }
+    Ok(DiagnosticResponses::with_errors(matches, response, errors))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2379,6 +2949,21 @@ mod tests {
         .unwrap()
     }
 
+    #[test]
+    fn normalizes_a_closed_uds_did_response_with_carly_padding() {
+        let responses = normalize_uds_responses("7E8 05 62 11 4F 04 F8 55 55\r>", 0x114f).unwrap();
+        assert_eq!(responses.as_slice().len(), 1);
+        assert_eq!(
+            responses.as_slice()[0].responder.as_ref().unwrap().as_str(),
+            "7E8"
+        );
+        assert_eq!(
+            responses.as_slice()[0].payload,
+            [0x62, 0x11, 0x4f, 0x04, 0xf8]
+        );
+        assert!(responses.errors().is_empty());
+    }
+
     fn channel() -> Characteristic {
         Characteristic {
             uuid: uuid_from_u16(CARLY_CHANNEL),
@@ -2417,6 +3002,9 @@ mod tests {
                     }
                     SessionCommand::ReadTargeted { reply, .. } => {
                         let _ = reply.send(Err("targeted test request not scripted".into()));
+                    }
+                    SessionCommand::ReadDpfProbe { reply, .. } => {
+                        let _ = reply.send(Err("DPF probe test request not scripted".into()));
                     }
                     SessionCommand::ReadStoredDtcs { reply } => {
                         let _ = reply.send(Err("stored DTC test request not scripted".into()));

--- a/src/diagnostic_job.rs
+++ b/src/diagnostic_job.rs
@@ -7,6 +7,8 @@
 
 use std::{fmt, str::FromStr};
 
+use crate::ea189::Ea189DpfProbe;
+
 /// Version of the stable job vocabulary and its deterministic plan shape.
 pub const JOB_MODEL_VERSION: u16 = 1;
 
@@ -15,14 +17,18 @@ pub const JOB_MODEL_VERSION: u16 = 1;
 pub enum JobId {
     /// Read the bounded set of DTC information represented by this job.
     DtcScan,
+    /// Read the closed, candidate-only EA189 DPF probe set.
+    Ea189DpfProbe,
 }
 
 impl JobId {
     pub const DTC_SCAN: Self = Self::DtcScan;
+    pub const EA189_DPF_PROBE: Self = Self::Ea189DpfProbe;
 
     pub const fn id(self) -> &'static str {
         match self {
             Self::DtcScan => "dtc.scan",
+            Self::Ea189DpfProbe => "ea189.dpf.probe",
         }
     }
 
@@ -33,6 +39,7 @@ impl JobId {
     pub fn parse(value: &str) -> Result<Self, JobError> {
         match value {
             "dtc.scan" => Ok(Self::DtcScan),
+            "ea189.dpf.probe" => Ok(Self::Ea189DpfProbe),
             value => Err(JobError::UnknownJobId(value.into())),
         }
     }
@@ -64,12 +71,14 @@ impl TryFrom<&str> for JobId {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum JobKind {
     DtcScan,
+    Ea189DpfProbe,
 }
 
 impl JobKind {
     pub const fn job_id(self) -> JobId {
         match self {
             Self::DtcScan => JobId::DtcScan,
+            Self::Ea189DpfProbe => JobId::Ea189DpfProbe,
         }
     }
 
@@ -102,6 +111,7 @@ impl From<JobId> for JobKind {
     fn from(id: JobId) -> Self {
         match id {
             JobId::DtcScan => Self::DtcScan,
+            JobId::Ea189DpfProbe => Self::Ea189DpfProbe,
         }
     }
 }
@@ -268,12 +278,36 @@ impl DiagnosticJob {
         }
     }
 
+    pub fn try_new(kind: JobKind, scope: DiagnosticScope) -> Result<Self, JobError> {
+        if matches!(kind, JobKind::Ea189DpfProbe)
+            && !matches!(
+                &scope,
+                DiagnosticScope::KnownEcu {
+                    role: EcuRole::Engine,
+                    ..
+                }
+            )
+        {
+            return Err(JobError::RequiresKnownEngineEcu);
+        }
+        Ok(Self::new(kind, scope))
+    }
+
     pub fn from_id(id: &str, scope: DiagnosticScope) -> Result<Self, JobError> {
-        Ok(Self::new(JobId::parse(id)?.into(), scope))
+        Self::try_new(JobId::parse(id)?.into(), scope)
     }
 
     pub fn dtc_scan(scope: DiagnosticScope) -> Self {
         Self::new(JobKind::DtcScan, scope)
+    }
+
+    /// Build the bounded EA189 DPF probe against one already-known engine
+    /// ECU. The constructor cannot create a vehicle-wide or functional scan.
+    pub fn ea189_dpf_probe(target: KnownTarget) -> Self {
+        Self::new(
+            JobKind::Ea189DpfProbe,
+            DiagnosticScope::known_ecu(EcuRole::Engine, target),
+        )
     }
 
     pub const fn id(&self) -> JobId {
@@ -301,6 +335,7 @@ impl DiagnosticJob {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum JobStepKind {
     ReadDtc,
+    ReadEa189Dpf(Ea189DpfProbe),
 }
 
 /// One planned, ordered semantic read.  The sequence is zero-based and is
@@ -313,10 +348,10 @@ pub struct JobStep {
 }
 
 impl JobStep {
-    fn new(sequence: usize, target: JobTarget) -> Self {
+    fn new(sequence: usize, kind: JobStepKind, target: JobTarget) -> Self {
         Self {
             sequence,
-            kind: JobStepKind::ReadDtc,
+            kind,
             target,
         }
     }
@@ -327,6 +362,13 @@ impl JobStep {
 
     pub const fn kind(&self) -> JobStepKind {
         self.kind
+    }
+
+    pub const fn dpf_probe(&self) -> Option<Ea189DpfProbe> {
+        match self.kind {
+            JobStepKind::ReadEa189Dpf(probe) => Some(probe),
+            JobStepKind::ReadDtc => None,
+        }
     }
 
     pub fn target(&self) -> &JobTarget {
@@ -347,13 +389,35 @@ pub struct JobPlan {
 
 impl JobPlan {
     pub fn for_job(job: &DiagnosticJob) -> Self {
-        let steps = job
-            .scope
-            .targets()
-            .into_iter()
-            .enumerate()
-            .map(|(sequence, target)| JobStep::new(sequence, target))
-            .collect();
+        let steps = match job.kind {
+            JobKind::DtcScan => job
+                .scope
+                .targets()
+                .into_iter()
+                .enumerate()
+                .map(|(sequence, target)| JobStep::new(sequence, JobStepKind::ReadDtc, target))
+                .collect(),
+            JobKind::Ea189DpfProbe => match &job.scope {
+                DiagnosticScope::KnownEcu {
+                    role: EcuRole::Engine,
+                    target,
+                } => Ea189DpfProbe::ALL
+                    .into_iter()
+                    .enumerate()
+                    .map(|(sequence, probe)| {
+                        JobStep::new(
+                            sequence,
+                            JobStepKind::ReadEa189Dpf(probe),
+                            JobTarget::KnownEcu {
+                                role: EcuRole::Engine,
+                                target: target.clone(),
+                            },
+                        )
+                    })
+                    .collect(),
+                _ => Vec::new(),
+            },
+        };
         Self {
             model_version: JOB_MODEL_VERSION,
             id: job.id,
@@ -709,6 +773,7 @@ impl JobStepResult {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum JobError {
     UnknownJobId(String),
+    RequiresKnownEngineEcu,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -738,6 +803,9 @@ impl fmt::Display for JobError {
         match self {
             Self::UnknownJobId(value) => {
                 write!(formatter, "unsupported diagnostic job id: {value}")
+            }
+            Self::RequiresKnownEngineEcu => {
+                formatter.write_str("EA189 DPF probe requires a known engine ECU scope")
             }
         }
     }
@@ -807,9 +875,38 @@ mod tests {
     fn only_supported_job_id_has_stable_serialization() {
         assert_eq!(JobId::DtcScan.to_string(), "dtc.scan");
         assert_eq!(JobId::parse("dtc.scan"), Ok(JobId::DtcScan));
+        assert_eq!(JobId::Ea189DpfProbe.to_string(), "ea189.dpf.probe");
+        assert_eq!(JobId::parse("ea189.dpf.probe"), Ok(JobId::Ea189DpfProbe));
         assert_eq!(
             JobId::parse("dtc.clear"),
             Err(JobError::UnknownJobId("dtc.clear".into()))
+        );
+    }
+
+    #[test]
+    fn ea189_dpf_probe_plan_is_bounded_to_the_known_engine() {
+        let target = KnownTarget::new("validated-engine").unwrap();
+        let plan = DiagnosticJob::ea189_dpf_probe(target).plan();
+        assert_eq!(plan.id(), JobId::Ea189DpfProbe);
+        assert_eq!(plan.steps().len(), 7);
+        for (sequence, step) in plan.steps().iter().enumerate() {
+            assert_eq!(step.sequence(), sequence);
+            assert!(matches!(step.kind(), JobStepKind::ReadEa189Dpf(_)));
+            assert!(matches!(
+                step.target(),
+                JobTarget::KnownEcu {
+                    role: EcuRole::Engine,
+                    target: KnownTarget(value),
+                } if value == "validated-engine"
+            ));
+        }
+    }
+
+    #[test]
+    fn ea189_dpf_probe_job_rejects_non_engine_scopes() {
+        assert_eq!(
+            DiagnosticJob::try_new(JobKind::Ea189DpfProbe, DiagnosticScope::vehicle_wide(),),
+            Err(JobError::RequiresKnownEngineEcu)
         );
     }
 

--- a/src/ea189.rs
+++ b/src/ea189.rs
@@ -7,6 +7,7 @@
 use std::collections::BTreeMap;
 
 use crate::{
+    diagnostic_job::{DiagnosticScope, EcuRole as JobEcuRole, KnownTarget},
     topology::{AddressingContext, Confidence, EcuRole, Protocol, Provenance},
     vehicle_knowledge::EcuTargetMapping,
     ReadRequest,
@@ -18,6 +19,184 @@ pub const PROFILE_ID: &str = "vw-ea189-v1";
 /// Human-readable platform identity.  This is intentionally not a VIN or a
 /// vehicle-specific identity.
 pub const PLATFORM: &str = "VW EA189";
+
+/// One candidate UDS ReadDataByIdentifier definition admitted by the closed
+/// Gate-A DPF probe.  The definition intentionally contains no interpretation
+/// of the returned payload.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Ea189DpfDid {
+    semantic: &'static str,
+    id: u16,
+    request_bytes: [u8; 3],
+}
+
+impl Ea189DpfDid {
+    pub const fn semantic(self) -> &'static str {
+        self.semantic
+    }
+
+    pub const fn id(self) -> u16 {
+        self.id
+    }
+
+    pub const fn request_bytes(self) -> [u8; 3] {
+        self.request_bytes
+    }
+}
+
+const DPF_SOOT_MASS_MEASURED: Ea189DpfDid = Ea189DpfDid {
+    semantic: "dpf.soot_mass_measured",
+    id: 0x114e,
+    request_bytes: [0x22, 0x11, 0x4e],
+};
+const DPF_SOOT_MASS_CALCULATED: Ea189DpfDid = Ea189DpfDid {
+    semantic: "dpf.soot_mass_calculated",
+    id: 0x114f,
+    request_bytes: [0x22, 0x11, 0x4f],
+};
+const DPF_DISTANCE_SINCE_REGENERATION: Ea189DpfDid = Ea189DpfDid {
+    semantic: "dpf.distance_since_regeneration",
+    id: 0x1156,
+    request_bytes: [0x22, 0x11, 0x56],
+};
+const DPF_TIME_SINCE_REGENERATION: Ea189DpfDid = Ea189DpfDid {
+    semantic: "dpf.time_since_regeneration",
+    id: 0x115e,
+    request_bytes: [0x22, 0x11, 0x5e],
+};
+const DPF_PRE_TEMPERATURE: Ea189DpfDid = Ea189DpfDid {
+    semantic: "exhaust.temperature.pre_dpf",
+    id: 0x11b2,
+    request_bytes: [0x22, 0x11, 0xb2],
+};
+const DPF_POST_TEMPERATURE: Ea189DpfDid = Ea189DpfDid {
+    semantic: "exhaust.temperature.post_dpf",
+    id: 0x10f9,
+    request_bytes: [0x22, 0x10, 0xf9],
+};
+const DPF_DIFFERENTIAL_PRESSURE: Ea189DpfDid = Ea189DpfDid {
+    semantic: "dpf.differential_pressure",
+    id: 0x14f5,
+    request_bytes: [0x22, 0x14, 0xf5],
+};
+
+/// Exactly the seven bounded EA189 DPF candidates admitted for Gate A.
+pub const EA189_DPF_DIDS: [Ea189DpfDid; 7] = [
+    DPF_SOOT_MASS_CALCULATED,
+    DPF_SOOT_MASS_MEASURED,
+    DPF_DISTANCE_SINCE_REGENERATION,
+    DPF_TIME_SINCE_REGENERATION,
+    DPF_PRE_TEMPERATURE,
+    DPF_POST_TEMPERATURE,
+    DPF_DIFFERENTIAL_PRESSURE,
+];
+
+/// A closed selection from the Gate-A DPF candidate set.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Ea189DpfProbe {
+    SootMassMeasured,
+    SootMassCalculated,
+    DistanceSinceRegeneration,
+    TimeSinceRegeneration,
+    PreDpfTemperature,
+    PostDpfTemperature,
+    DifferentialPressure,
+}
+
+impl Ea189DpfProbe {
+    pub const ALL: [Self; 7] = [
+        Self::SootMassCalculated,
+        Self::SootMassMeasured,
+        Self::DistanceSinceRegeneration,
+        Self::TimeSinceRegeneration,
+        Self::PreDpfTemperature,
+        Self::PostDpfTemperature,
+        Self::DifferentialPressure,
+    ];
+
+    pub const fn definition(self) -> Ea189DpfDid {
+        match self {
+            Self::SootMassMeasured => DPF_SOOT_MASS_MEASURED,
+            Self::SootMassCalculated => DPF_SOOT_MASS_CALCULATED,
+            Self::DistanceSinceRegeneration => DPF_DISTANCE_SINCE_REGENERATION,
+            Self::TimeSinceRegeneration => DPF_TIME_SINCE_REGENERATION,
+            Self::PreDpfTemperature => DPF_PRE_TEMPERATURE,
+            Self::PostDpfTemperature => DPF_POST_TEMPERATURE,
+            Self::DifferentialPressure => DPF_DIFFERENTIAL_PRESSURE,
+        }
+    }
+
+    pub const fn semantic(self) -> &'static str {
+        self.definition().semantic()
+    }
+
+    pub const fn id(self) -> u16 {
+        self.definition().id()
+    }
+
+    pub const fn request_bytes(self) -> [u8; 3] {
+        self.definition().request_bytes()
+    }
+}
+
+/// Target-bound DPF probe input. Construction only accepts an engine
+/// `KnownEcu` scope, so a candidate cannot be detached into a vehicle-wide or
+/// functional operation.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Ea189DpfProbeRequest {
+    probe: Ea189DpfProbe,
+    scope: DiagnosticScope,
+}
+
+impl Ea189DpfProbeRequest {
+    pub fn for_engine(probe: Ea189DpfProbe, target: KnownTarget) -> Self {
+        Self {
+            probe,
+            scope: DiagnosticScope::known_ecu(JobEcuRole::Engine, target),
+        }
+    }
+
+    pub fn from_scope(
+        probe: Ea189DpfProbe,
+        scope: DiagnosticScope,
+    ) -> Result<Self, Ea189DpfProbeError> {
+        match &scope {
+            DiagnosticScope::KnownEcu {
+                role: JobEcuRole::Engine,
+                ..
+            } => Ok(Self { probe, scope }),
+            _ => Err(Ea189DpfProbeError::RequiresEngineKnownEcu),
+        }
+    }
+
+    pub const fn probe(&self) -> Ea189DpfProbe {
+        self.probe
+    }
+
+    pub fn scope(&self) -> &DiagnosticScope {
+        &self.scope
+    }
+
+    pub fn target(&self) -> &KnownTarget {
+        match &self.scope {
+            DiagnosticScope::KnownEcu { target, .. } => target,
+            _ => unreachable!("EA189 DPF probe scope is engine KnownEcu"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Ea189DpfProbeError {
+    RequiresEngineKnownEcu,
+}
+
+impl std::fmt::Display for Ea189DpfProbeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("EA189 DPF probe requires a known engine ECU target")
+    }
+}
+
+impl std::error::Error for Ea189DpfProbeError {}
 
 /// Identity of the platform knowledge, independent of any one vehicle.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -285,6 +464,56 @@ mod tests {
         assert_ne!(profile.identity().id(), "obd2-v1");
         assert!(profile.signals().next().is_none());
         assert!(!format!("{profile:?}").contains("VIN"));
+    }
+
+    #[test]
+    fn gate_a_dpf_probe_is_exactly_seven_candidate_reads() {
+        let expected = [
+            ("dpf.soot_mass_calculated", 0x114f, [0x22, 0x11, 0x4f]),
+            ("dpf.soot_mass_measured", 0x114e, [0x22, 0x11, 0x4e]),
+            (
+                "dpf.distance_since_regeneration",
+                0x1156,
+                [0x22, 0x11, 0x56],
+            ),
+            ("dpf.time_since_regeneration", 0x115e, [0x22, 0x11, 0x5e]),
+            ("exhaust.temperature.pre_dpf", 0x11b2, [0x22, 0x11, 0xb2]),
+            ("exhaust.temperature.post_dpf", 0x10f9, [0x22, 0x10, 0xf9]),
+            ("dpf.differential_pressure", 0x14f5, [0x22, 0x14, 0xf5]),
+        ];
+        assert_eq!(EA189_DPF_DIDS.len(), expected.len());
+        assert_eq!(Ea189DpfProbe::ALL.len(), expected.len());
+        for ((definition, probe), expected) in
+            EA189_DPF_DIDS.iter().zip(Ea189DpfProbe::ALL).zip(expected)
+        {
+            assert_eq!(
+                (
+                    definition.semantic(),
+                    definition.id(),
+                    definition.request_bytes()
+                ),
+                expected
+            );
+            assert_eq!(probe.definition(), *definition);
+        }
+    }
+
+    #[test]
+    fn dpf_probe_request_requires_an_engine_known_ecu() {
+        let target = KnownTarget::new("validated-engine").unwrap();
+        let request =
+            Ea189DpfProbeRequest::for_engine(Ea189DpfProbe::SootMassMeasured, target.clone());
+        assert_eq!(request.target().as_str(), "validated-engine");
+        assert!(Ea189DpfProbeRequest::from_scope(
+            Ea189DpfProbe::SootMassMeasured,
+            DiagnosticScope::vehicle_wide(),
+        )
+        .is_err());
+        assert!(Ea189DpfProbeRequest::from_scope(
+            Ea189DpfProbe::SootMassMeasured,
+            DiagnosticScope::known_ecu(JobEcuRole::Unknown, target,),
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use obdentic::{
         DtcTransportOutcome, SubscriptionFilterOutcome,
     },
     capture_report, capture_tui,
-    diagnostic_job::{DiagnosticJob, DiagnosticScope, JobStatus},
+    diagnostic_job::{DiagnosticJob, DiagnosticScope, JobStatus, KnownTarget},
     dtc, hex, jsonl_capture,
     layout_observation::{self, LayoutFreshnessPolicy},
     prepare_read, record, replay,
@@ -40,7 +40,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
+const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic diagnose ea189.dpf.probe --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
 
 #[derive(Debug, PartialEq, Eq)]
 enum Command {
@@ -50,6 +50,10 @@ enum Command {
     },
     Scan,
     DiagnoseDtcScan {
+        adapter_id: String,
+        recording: Option<String>,
+    },
+    DiagnoseEa189DpfProbe {
         adapter_id: String,
         recording: Option<String>,
     },
@@ -146,6 +150,18 @@ async fn run() -> Result<(), String> {
                 recording,
             } => {
                 run_diagnose_dtc_scan(
+                    &adapter_id,
+                    recording.as_deref().map(Path::new),
+                    &runtime,
+                    &mut runtime_state,
+                )
+                .await
+            }
+            Command::DiagnoseEa189DpfProbe {
+                adapter_id,
+                recording,
+            } => {
+                run_diagnose_ea189_dpf_probe(
                     &adapter_id,
                     recording.as_deref().map(Path::new),
                     &runtime,
@@ -1019,6 +1035,268 @@ async fn run_diagnose_dtc_scan_inner(
     }
 }
 
+async fn run_diagnose_ea189_dpf_probe(
+    adapter_id: &str,
+    recording: Option<&Path>,
+    runtime: &RuntimeClient,
+    state: &mut RuntimeState,
+) -> Result<(), String> {
+    let started = Instant::now();
+    let recorder = recording
+        .map(jsonl_capture::JsonlRecorder::start)
+        .transpose()?;
+    let sender = recorder.as_ref().map(jsonl_capture::JsonlRecorder::sender);
+    let result = async {
+        if sender.is_some() {
+            emit_capture_event(
+                sender,
+                CaptureEvent::capture_started(
+                    Some(wallclock_ms()?),
+                    Some("ea189.dpf.probe".into()),
+                ),
+            )
+            .await?;
+            apply_runtime_event(
+                runtime,
+                state,
+                sender,
+                RuntimeEvent::recording(RecordingState::Active),
+            )
+            .await?;
+        }
+        run_diagnose_ea189_dpf_probe_inner(adapter_id, runtime, state, sender).await
+    }
+    .await;
+    let inactive = if sender.is_some() {
+        apply_runtime_event(
+            runtime,
+            state,
+            sender,
+            RuntimeEvent::recording(RecordingState::Inactive),
+        )
+        .await
+    } else {
+        Ok(())
+    };
+    let shutdown = finish_runtime(runtime, state, sender).await;
+    let stopped = emit_capture_event(
+        sender,
+        CaptureEvent::SessionStopped {
+            offset_us: started
+                .elapsed()
+                .as_micros()
+                .try_into()
+                .map_err(|_| "EA189 DPF capture duration exceeds supported range")?,
+        },
+    )
+    .await;
+    let recorded = match recorder {
+        Some(recorder) => recorder.close().await,
+        None => Ok(()),
+    };
+    result
+        .and(inactive)
+        .and(shutdown)
+        .and(stopped)
+        .and(recorded)
+}
+
+async fn run_diagnose_ea189_dpf_probe_inner(
+    adapter_id: &str,
+    runtime: &RuntimeClient,
+    state: &mut RuntimeState,
+    recorder: Option<&jsonl_capture::Sender>,
+) -> Result<(), String> {
+    let mapping = cached_engine_mapping(adapter_id).await?;
+    let target = mapping
+        .target()
+        .target()
+        .address()
+        .ok_or_else(|| "validated engine target is missing a concrete address".to_string())?;
+    let job = DiagnosticJob::ea189_dpf_probe(
+        KnownTarget::new(target.value()).map_err(|error| error.to_string())?,
+    );
+    let plan = job.plan();
+
+    apply_runtime_event(
+        runtime,
+        state,
+        recorder,
+        RuntimeEvent::source(SourceState::Live),
+    )
+    .await?;
+    apply_runtime_event(
+        runtime,
+        state,
+        recorder,
+        RuntimeEvent::vehicle(VehicleState::Identified),
+    )
+    .await?;
+    apply_runtime_event(
+        runtime,
+        state,
+        recorder,
+        RuntimeEvent::topology(TopologyState::Validated),
+    )
+    .await?;
+    apply_runtime_event(
+        runtime,
+        state,
+        recorder,
+        RuntimeEvent::transport(TransportState::Connecting),
+    )
+    .await?;
+    let prepared = ble::prepare_diagnostic_session(adapter_id).await?;
+    record_protocol_negotiation(recorder, prepared.negotiation()).await?;
+    apply_runtime_event(
+        runtime,
+        state,
+        recorder,
+        RuntimeEvent::transport(TransportState::Connected),
+    )
+    .await?;
+    apply_runtime_event(runtime, state, recorder, RuntimeEvent::DiagnosticJobStarted).await?;
+    emit_capture_event(recorder, CaptureEvent::diagnostic_job_started(&job)).await?;
+
+    let mut recoverable = false;
+    for step in plan.steps() {
+        let probe = step
+            .dpf_probe()
+            .ok_or_else(|| "EA189 DPF plan contains a non-probe step".to_string())?;
+        match SafetyPolicy::read_only().authorize_activity(
+            Activity::Diagnose,
+            OperationRequest::ea189_dpf_probe(probe, job_target(&job)?),
+        ) {
+            Ok(Operation::Ea189DpfProbe(_)) => {}
+            Ok(_) => {
+                return Err("read-only safety policy returned the wrong EA189 operation".into())
+            }
+            Err(error) => return Err(error.to_string()),
+        }
+        let request = ble::TargetedDpfProbeRequest::from_mapping(probe, &mapping)?;
+        match prepared.read_dpf_probe(request).await {
+            Ok(responses) => {
+                let response = responses.as_slice().first().ok_or_else(|| {
+                    format!("{} returned no normalized response", probe.semantic())
+                })?;
+                let expected_responder = mapping.expected_responder().value();
+                let responder_matches = response
+                    .responder
+                    .as_ref()
+                    .is_some_and(|responder| Some(responder.as_str()) == expected_responder);
+                let status = if response.payload.starts_with(&[
+                    0x62,
+                    probe.request_bytes()[1],
+                    probe.request_bytes()[2],
+                ]) && responder_matches
+                {
+                    DiagnosticJobStepStatus::Success
+                } else {
+                    recoverable = true;
+                    DiagnosticJobStepStatus::Recoverable
+                };
+                let selected = responder_matches.then(|| {
+                    response
+                        .responder
+                        .as_ref()
+                        .expect("matching responder is present")
+                        .as_str()
+                        .to_owned()
+                });
+                emit_capture_event(
+                    recorder,
+                    CaptureEvent::responses_observed(
+                        probe.semantic(),
+                        probe.request_bytes().into(),
+                        responses.capture_evidence(),
+                        selected.clone(),
+                        (status != DiagnosticJobStepStatus::Success)
+                            .then_some("unexpected_or_negative_uds_response".into()),
+                    )?,
+                )
+                .await?;
+                emit_capture_event(
+                    recorder,
+                    CaptureEvent::diagnostic_job_step(
+                        job.id().to_string(),
+                        step.sequence()
+                            .try_into()
+                            .map_err(|_| "EA189 DPF step index exceeds u64")?,
+                        0x22,
+                        selected.clone(),
+                        status,
+                        (status != DiagnosticJobStepStatus::Success)
+                            .then_some("negative_or_malformed_response".into()),
+                    )?,
+                )
+                .await?;
+                println!(
+                    "probe\t{}\t{:04X}\t{}\t{}",
+                    probe.semantic(),
+                    probe.id(),
+                    selected.unwrap_or_else(|| "unknown".into()),
+                    hex(&response.payload),
+                );
+            }
+            Err(error) => {
+                recoverable = true;
+                emit_capture_event(
+                    recorder,
+                    CaptureEvent::diagnostic_job_step(
+                        job.id().to_string(),
+                        step.sequence()
+                            .try_into()
+                            .map_err(|_| "EA189 DPF step index exceeds u64")?,
+                        0x22,
+                        None,
+                        DiagnosticJobStepStatus::Recoverable,
+                        Some(error.clone()),
+                    )?,
+                )
+                .await?;
+                println!(
+                    "probe\t{}\t{:04X}\terror\t{error}",
+                    probe.semantic(),
+                    probe.id()
+                );
+            }
+        }
+    }
+    let shutdown = prepared.shutdown().await;
+    emit_capture_event(
+        recorder,
+        CaptureEvent::DiagnosticJobCompleted {
+            job_id: job.id().to_string(),
+            status: if recoverable {
+                JobStatus::CompletedWithErrors
+            } else {
+                JobStatus::Completed
+            },
+        },
+    )
+    .await?;
+    finish_diagnostic(runtime, state, recorder).await?;
+    shutdown
+}
+
+fn job_target(job: &DiagnosticJob) -> Result<KnownTarget, String> {
+    match job.scope() {
+        DiagnosticScope::KnownEcu { target, .. } => Ok(target.clone()),
+        _ => Err("EA189 DPF job lost its known engine target".into()),
+    }
+}
+
+async fn cached_engine_mapping(adapter_id: &str) -> Result<EcuTargetMapping, String> {
+    let (mappings, cache_valid) = cached_routing_mappings(adapter_id).await;
+    if !cache_valid {
+        return Err("EA189 DPF probe requires a validated engine mapping; run `obdentic vehicle discover --adapter <UUID>` first".into());
+    }
+    mappings
+        .into_iter()
+        .find(|mapping| mapping.role().role() == &EcuRole::Engine)
+        .ok_or_else(|| "EA189 DPF probe requires a validated engine mapping; run `obdentic vehicle discover --adapter <UUID>` first".into())
+}
+
 async fn finish_diagnostic(
     runtime: &RuntimeClient,
     state: &mut RuntimeState,
@@ -1714,6 +1992,15 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
                 recording: None,
             })
         }
+        [command, job, adapter_flag, adapter_id]
+            if command == "diagnose" && job == "ea189.dpf.probe" && adapter_flag == "--adapter" =>
+        {
+            require_uuid(adapter_id)?;
+            Ok(Command::DiagnoseEa189DpfProbe {
+                adapter_id: adapter_id.clone(),
+                recording: None,
+            })
+        }
         [command, job, adapter_flag, adapter_id, record_flag, path]
             if command == "diagnose"
                 && job == "dtc.scan"
@@ -1722,6 +2009,18 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
         {
             require_uuid(adapter_id)?;
             Ok(Command::DiagnoseDtcScan {
+                adapter_id: adapter_id.clone(),
+                recording: Some(path.clone()),
+            })
+        }
+        [command, job, adapter_flag, adapter_id, record_flag, path]
+            if command == "diagnose"
+                && job == "ea189.dpf.probe"
+                && adapter_flag == "--adapter"
+                && record_flag == "--record" =>
+        {
+            require_uuid(adapter_id)?;
+            Ok(Command::DiagnoseEa189DpfProbe {
                 adapter_id: adapter_id.clone(),
                 recording: Some(path.clone()),
             })
@@ -2107,6 +2406,20 @@ mod tests {
             Ok(Command::DiagnoseDtcScan {
                 adapter_id: uuid.into(),
                 recording: Some("dtc.jsonl".into()),
+            })
+        );
+        assert_eq!(
+            parse_command(&args(&[
+                "diagnose",
+                "ea189.dpf.probe",
+                "--adapter",
+                uuid,
+                "--record",
+                "dpf.jsonl",
+            ])),
+            Ok(Command::DiagnoseEa189DpfProbe {
+                adapter_id: uuid.into(),
+                recording: Some("dpf.jsonl".into()),
             })
         );
         assert_eq!(

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -51,6 +51,23 @@ impl ReadOperation {
         Self::UdsReadDataByIdentifier { did }
     }
 
+    pub(crate) const fn request_bytes(self) -> [u8; 3] {
+        match self {
+            Self::UdsReadDataByIdentifier { did } => {
+                let [high, low] = did.to_be_bytes();
+                [0x22, high, low]
+            }
+            Self::Mode01(_) => panic!("Mode01 request is not a UDS request"),
+        }
+    }
+
+    pub(crate) const fn did(self) -> u16 {
+        match self {
+            Self::UdsReadDataByIdentifier { did } => did,
+            Self::Mode01(_) => panic!("Mode01 request is not a UDS request"),
+        }
+    }
+
     pub(crate) fn validate_response<'a>(
         self,
         response: &'a [u8],

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -5,7 +5,13 @@
 //! [`Operation`].  Since `Operation` has only read-only variants, a rejected
 //! request cannot be passed to a transport by accident.
 
-use crate::{prepare_read, runtime_state::Activity, ReadRequest};
+use crate::{
+    diagnostic_job::{DiagnosticScope, KnownTarget},
+    ea189::{Ea189DpfProbe, Ea189DpfProbeError, Ea189DpfProbeRequest},
+    prepare_read,
+    runtime_state::Activity,
+    ReadRequest,
+};
 use std::fmt;
 
 /// Standards-based OBD-II DTC read selection.
@@ -63,6 +69,7 @@ pub enum OperationKind {
     Write,
     SignalRead,
     DtcRead,
+    Ea189DpfProbe,
     DtcClear,
     SecurityAccess,
     DiagnosticSessionControl,
@@ -82,10 +89,11 @@ pub enum OperationKind {
 ///
 /// The blocked variants are request vocabulary only.  They can never become
 /// an [`Operation`], and no variant carries caller-provided protocol bytes.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum OperationRequest {
     ReadSignal(ReadRequest),
     ReadDtcs(DtcReadKind),
+    Ea189DpfProbe(Ea189DpfProbeRequest),
     ClearDtcs,
     SecurityAccess,
     DiagnosticSessionControl,
@@ -123,10 +131,22 @@ impl OperationRequest {
         Self::ReadDtcs(kind)
     }
 
-    pub const fn kind(self) -> OperationKind {
+    pub fn ea189_dpf_probe(probe: Ea189DpfProbe, target: KnownTarget) -> Self {
+        Self::Ea189DpfProbe(Ea189DpfProbeRequest::for_engine(probe, target))
+    }
+
+    pub fn ea189_dpf_probe_for_scope(
+        probe: Ea189DpfProbe,
+        scope: DiagnosticScope,
+    ) -> Result<Self, Ea189DpfProbeError> {
+        Ea189DpfProbeRequest::from_scope(probe, scope).map(Self::Ea189DpfProbe)
+    }
+
+    pub const fn kind(&self) -> OperationKind {
         match self {
             Self::ReadSignal(_) => OperationKind::SignalRead,
             Self::ReadDtcs(_) => OperationKind::DtcRead,
+            Self::Ea189DpfProbe(_) => OperationKind::Ea189DpfProbe,
             Self::ClearDtcs => OperationKind::DtcClear,
             Self::SecurityAccess => OperationKind::SecurityAccess,
             Self::DiagnosticSessionControl => OperationKind::DiagnosticSessionControl,
@@ -145,17 +165,19 @@ impl OperationRequest {
 }
 
 /// The only operations that can leave the safety layer for transport.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Operation {
     ReadSignal(ReadRequest),
     ReadDtcs(DtcReadKind),
+    Ea189DpfProbe(Ea189DpfProbeRequest),
 }
 
 impl Operation {
-    pub const fn kind(self) -> OperationKind {
+    pub const fn kind(&self) -> OperationKind {
         match self {
             Self::ReadSignal(_) => OperationKind::SignalRead,
             Self::ReadDtcs(_) => OperationKind::DtcRead,
+            Self::Ea189DpfProbe(_) => OperationKind::Ea189DpfProbe,
         }
     }
 
@@ -169,6 +191,10 @@ impl Operation {
 
     pub const fn dtc(kind: DtcReadKind) -> Self {
         Self::ReadDtcs(kind)
+    }
+
+    pub fn ea189_dpf_probe(request: Ea189DpfProbeRequest) -> Self {
+        Self::Ea189DpfProbe(request)
     }
 }
 
@@ -194,7 +220,7 @@ impl Capability {
         match self {
             Self::ReadOnly => matches!(
                 operation,
-                OperationKind::SignalRead | OperationKind::DtcRead
+                OperationKind::SignalRead | OperationKind::DtcRead | OperationKind::Ea189DpfProbe
             ),
         }
     }
@@ -267,10 +293,13 @@ impl SafetyPolicy {
     }
 
     /// Authorize a concrete request independently of runtime activity.
-    pub const fn authorize(self, request: OperationRequest) -> Result<Operation, SafetyError> {
+    pub fn authorize(self, request: OperationRequest) -> Result<Operation, SafetyError> {
         match request {
             OperationRequest::ReadSignal(signal) => self.authorize_read(signal),
             OperationRequest::ReadDtcs(kind) => self.authorize_operation(Operation::ReadDtcs(kind)),
+            OperationRequest::Ea189DpfProbe(probe) => {
+                self.authorize_operation(Operation::Ea189DpfProbe(probe))
+            }
             OperationRequest::ClearDtcs => {
                 Err(SafetyError::OperationBlocked(OperationKind::DtcClear))
             }
@@ -332,7 +361,10 @@ impl SafetyPolicy {
                 matches!(operation, OperationKind::SignalRead)
             }
             Activity::Diagnose => {
-                matches!(operation, OperationKind::DtcRead)
+                matches!(
+                    operation,
+                    OperationKind::DtcRead | OperationKind::Ea189DpfProbe
+                )
             }
             Activity::Idle | Activity::Write => false,
         };
@@ -345,11 +377,11 @@ impl SafetyPolicy {
         Ok(executable)
     }
 
-    const fn authorize_read(self, request: ReadRequest) -> Result<Operation, SafetyError> {
+    fn authorize_read(self, request: ReadRequest) -> Result<Operation, SafetyError> {
         self.authorize_operation(Operation::signal(request))
     }
 
-    const fn authorize_operation(self, operation: Operation) -> Result<Operation, SafetyError> {
+    fn authorize_operation(self, operation: Operation) -> Result<Operation, SafetyError> {
         if self.capability.supports(operation.kind()) {
             Ok(operation)
         } else {
@@ -398,6 +430,39 @@ mod tests {
             ),
             Ok(Operation::ReadDtcs(DtcReadKind::Stored))
         );
+    }
+
+    #[test]
+    fn ea189_dpf_probe_is_read_only_and_engine_targeted() {
+        let target = crate::diagnostic_job::KnownTarget::new("validated-engine").unwrap();
+        let request = OperationRequest::ea189_dpf_probe(Ea189DpfProbe::SootMassMeasured, target);
+        assert_eq!(request.kind(), OperationKind::Ea189DpfProbe);
+        let operation = SafetyPolicy::default()
+            .authorize_activity(Activity::Diagnose, request)
+            .unwrap();
+        assert!(matches!(
+            operation,
+            Operation::Ea189DpfProbe(ref request)
+                if request.probe() == Ea189DpfProbe::SootMassMeasured
+                    && matches!(
+                        request.scope(),
+                        DiagnosticScope::KnownEcu {
+                            role: crate::diagnostic_job::EcuRole::Engine,
+                            ..
+                        }
+                    )
+        ));
+    }
+
+    #[test]
+    fn generic_signal_path_cannot_construct_an_ea189_dpf_did() {
+        assert!(OperationRequest::read_signal("dpf.soot_mass_measured").is_err());
+        let target = crate::diagnostic_job::KnownTarget::new("validated-engine").unwrap();
+        let request =
+            OperationRequest::ea189_dpf_probe(Ea189DpfProbe::DifferentialPressure, target);
+        assert!(SafetyPolicy::default()
+            .authorize_activity(Activity::Read, request)
+            .is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a closed, engine-targeted EA189 DPF Gate A diagnostic job
- allow only the seven researched default-context `22 <DID>` requests
- preserve normalized responder-scoped raw UDS evidence; do not decode or promote Vehicle Knowledge

## Validation
- `cargo +1.98.0 fmt --check`
- `cargo +1.98.0 test --locked`
- `cargo +1.98.0 clippy --all-targets -- -D warnings`
- `cargo +1.98.0 build --locked`
- owned-hardware Gate A: 7/7 positive responder-scoped responses with a complete private capture

Refs #14