### PR TITLE
Replay experimental EA189 DPF evidence

### DIFF
--- a/src/capture_replay.rs
+++ b/src/capture_replay.rs
@@ -6,7 +6,8 @@
 //! differences are reported as issues rather than rewritten.
 
 use crate::{
-    capture_events::{CaptureEvent, CaptureValue},
+    capture_events::{CaptureEvent, CaptureValue, ResponderEvidence},
+    ea189::{decode_experimental_dpf, Ea189DpfProbe, Ea189ExperimentalDpfReading},
     jsonl_capture::ParsedCapture,
     prepare_read,
     telemetry::TelemetryState,
@@ -19,6 +20,10 @@ pub enum ReplayIssueKind {
     RequestChanged,
     DecodeFailed,
     RecordedDecodeChanged,
+    UnsupportedDpfCandidate,
+    MalformedDpfEvidence,
+    NegativeDpfResponse,
+    WrongResponderSelection,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -47,10 +52,29 @@ impl ReplayIssue {
     }
 }
 
+/// A successful experimental DPF decode kept separate from generic telemetry.
+/// Gate-B candidates are not part of the production signal catalog yet.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DpfReplayReading {
+    reading: Ea189ExperimentalDpfReading,
+    responder: String,
+}
+
+impl DpfReplayReading {
+    pub const fn reading(&self) -> Ea189ExperimentalDpfReading {
+        self.reading
+    }
+
+    pub fn responder(&self) -> &str {
+        &self.responder
+    }
+}
+
 pub struct CaptureReplay {
     duration_us: u64,
     offsets_us: Vec<u64>,
     transactions: Vec<Transaction>,
+    dpf_readings: Vec<DpfReplayReading>,
     issues: Vec<ReplayIssue>,
 }
 
@@ -63,6 +87,7 @@ impl CaptureReplay {
     pub fn from_capture(capture: &ParsedCapture) -> Self {
         let mut duration_us = 0_u64;
         let mut decoded = Vec::<(u64, Transaction)>::new();
+        let mut dpf_readings = Vec::new();
         let mut issues = Vec::new();
 
         for event in &capture.events {
@@ -139,7 +164,28 @@ impl CaptureReplay {
                 } => {
                     duration_us = duration_us.max(timing.finished_us);
                 }
-                CaptureEvent::ReadFailed { timing: None, .. } => {}
+                CaptureEvent::ReadFailed { .. } => {}
+                CaptureEvent::ResponsesObserved {
+                    semantic,
+                    request_payload,
+                    responses,
+                    selected_responder,
+                    selection_error,
+                } => {
+                    let mut state = DpfReplayState {
+                        readings: &mut dpf_readings,
+                        issues: &mut issues,
+                        at_us: duration_us,
+                    };
+                    replay_dpf_responses(
+                        semantic,
+                        request_payload,
+                        responses,
+                        selected_responder,
+                        selection_error,
+                        &mut state,
+                    );
+                }
                 CaptureEvent::SlotsSkipped { last_due_us, .. } => {
                     duration_us = duration_us.max(*last_due_us);
                 }
@@ -157,6 +203,7 @@ impl CaptureReplay {
             duration_us,
             offsets_us,
             transactions,
+            dpf_readings,
             issues,
         }
     }
@@ -172,6 +219,12 @@ impl CaptureReplay {
 
     pub fn transactions(&self) -> &[Transaction] {
         &self.transactions
+    }
+
+    /// Successful Gate-B DPF decodes. These remain outside [`TelemetryState`]
+    /// until their hypotheses are promoted into the vehicle signal catalog.
+    pub fn dpf_readings(&self) -> &[DpfReplayReading] {
+        &self.dpf_readings
     }
 
     pub fn issues(&self) -> &[ReplayIssue] {
@@ -196,6 +249,167 @@ impl CaptureReplay {
     }
 }
 
+fn is_dpf_semantic(semantic: &str) -> bool {
+    semantic.starts_with("dpf.") || semantic.starts_with("exhaust.temperature.")
+}
+
+fn dpf_probe(semantic: &str) -> Option<Ea189DpfProbe> {
+    Ea189DpfProbe::ALL
+        .into_iter()
+        .find(|probe| probe.semantic() == semantic)
+}
+
+struct DpfReplayState<'a> {
+    readings: &'a mut Vec<DpfReplayReading>,
+    issues: &'a mut Vec<ReplayIssue>,
+    at_us: u64,
+}
+
+fn replay_dpf_responses(
+    semantic: &str,
+    request_payload: &[u8],
+    responses: &[ResponderEvidence],
+    selected_responder: &Option<String>,
+    selection_error: &Option<String>,
+    state: &mut DpfReplayState<'_>,
+) {
+    if !is_dpf_semantic(semantic) {
+        return;
+    }
+
+    let Some(probe) = dpf_probe(semantic) else {
+        dpf_issue(
+            state.issues,
+            state.at_us,
+            semantic,
+            ReplayIssueKind::UnsupportedDpfCandidate,
+            "semantic is not in the closed EA189 DPF candidate set",
+        );
+        return;
+    };
+
+    if request_payload != probe.request_bytes() {
+        dpf_issue(
+            state.issues,
+            state.at_us,
+            semantic,
+            ReplayIssueKind::MalformedDpfEvidence,
+            format!(
+                "recorded request {:?} does not match closed DPF request {:?}",
+                request_payload,
+                probe.request_bytes()
+            ),
+        );
+        return;
+    }
+
+    if responses.is_empty() {
+        dpf_issue(
+            state.issues,
+            state.at_us,
+            semantic,
+            ReplayIssueKind::MalformedDpfEvidence,
+            "DPF response evidence is empty",
+        );
+        return;
+    }
+
+    if let Some(error) = selection_error {
+        dpf_issue(
+            state.issues,
+            state.at_us,
+            semantic,
+            ReplayIssueKind::WrongResponderSelection,
+            format!("recorded responder selection failed: {error}"),
+        );
+        return;
+    }
+
+    let Some(selected_responder) = selected_responder.as_deref() else {
+        dpf_issue(
+            state.issues,
+            state.at_us,
+            semantic,
+            ReplayIssueKind::WrongResponderSelection,
+            "DPF evidence has no selected responder",
+        );
+        return;
+    };
+
+    let selected = responses
+        .iter()
+        .filter(|response| response.responder.as_deref() == Some(selected_responder));
+    let selected_matches = selected.collect::<Vec<_>>();
+    if selected_matches.len() != 1 {
+        dpf_issue(
+            state.issues,
+            state.at_us,
+            semantic,
+            ReplayIssueKind::WrongResponderSelection,
+            format!(
+                "selected responder {selected_responder} matches {} evidence entries",
+                selected_matches.len()
+            ),
+        );
+        return;
+    }
+
+    let response = &selected_matches[0].payload;
+    if let [0x7f, 0x22, nrc] = response.as_slice() {
+        dpf_issue(
+            state.issues,
+            state.at_us,
+            semantic,
+            ReplayIssueKind::NegativeDpfResponse,
+            format!("recorded UDS negative response NRC {nrc:02X}"),
+        );
+        return;
+    }
+    match decode_experimental_dpf(probe, response) {
+        Ok(reading) => state.readings.push(DpfReplayReading {
+            reading,
+            responder: selected_responder.to_owned(),
+        }),
+        Err(error) => {
+            let alternate_decodes = responses.iter().any(|candidate| {
+                candidate.responder.as_deref() != Some(selected_responder)
+                    && decode_experimental_dpf(probe, &candidate.payload).is_ok()
+            });
+            let kind = if alternate_decodes {
+                ReplayIssueKind::WrongResponderSelection
+            } else if matches!(
+                error,
+                crate::ea189::Ea189DpfDecodeError::UnsupportedProbe(_)
+            ) || matches!(
+                probe,
+                Ea189DpfProbe::DistanceSinceRegeneration
+                    | Ea189DpfProbe::TimeSinceRegeneration
+                    | Ea189DpfProbe::DifferentialPressure
+            ) {
+                ReplayIssueKind::UnsupportedDpfCandidate
+            } else {
+                ReplayIssueKind::MalformedDpfEvidence
+            };
+            dpf_issue(state.issues, state.at_us, semantic, kind, error.to_string());
+        }
+    }
+}
+
+fn dpf_issue(
+    issues: &mut Vec<ReplayIssue>,
+    at_us: u64,
+    semantic: &str,
+    kind: ReplayIssueKind,
+    detail: impl Into<String>,
+) {
+    issues.push(ReplayIssue {
+        at_us,
+        semantic: semantic.into(),
+        kind,
+        detail: detail.into(),
+    });
+}
+
 fn recorded_decode_changed(value: &CaptureValue, unit: &str, transaction: &Transaction) -> bool {
     unit != transaction.unit()
         || match value {
@@ -216,7 +430,10 @@ fn capture_value_text(value: &CaptureValue) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{capture_events::ReadTiming, jsonl_capture::CaptureStatus};
+    use crate::{
+        capture_events::{ReadTiming, ResponderEvidence},
+        jsonl_capture::CaptureStatus,
+    };
 
     fn successful_read(
         semantic: &str,
@@ -247,6 +464,25 @@ mod tests {
         ParsedCapture {
             events,
             status: CaptureStatus::Complete,
+        }
+    }
+
+    fn dpf_response(
+        semantic: &str,
+        request: Vec<u8>,
+        responder: Option<&str>,
+        payload: Vec<u8>,
+        selected_responder: Option<&str>,
+    ) -> CaptureEvent {
+        CaptureEvent::ResponsesObserved {
+            semantic: semantic.into(),
+            request_payload: request,
+            responses: vec![ResponderEvidence {
+                responder: responder.map(str::to_owned),
+                payload,
+            }],
+            selected_responder: selected_responder.map(str::to_owned),
+            selection_error: None,
         }
     }
 
@@ -373,5 +609,113 @@ mod tests {
         assert_eq!(replay.duration_us(), 4_200_000);
         assert!(replay.transactions().is_empty());
         assert!(replay.telemetry_full(4).unwrap().signals().next().is_none());
+    }
+
+    #[test]
+    fn dpf_replay_decodes_experimental_reading_without_generic_telemetry() {
+        let replay = CaptureReplay::from_capture(&capture(vec![dpf_response(
+            "dpf.soot_mass_calculated",
+            vec![0x22, 0x11, 0x4f],
+            Some("7E8"),
+            vec![0x62, 0x11, 0x4f, 0x04, 0xf8],
+            Some("7E8"),
+        )]));
+
+        assert_eq!(replay.transactions().len(), 0);
+        assert_eq!(replay.dpf_readings().len(), 1);
+        assert_eq!(replay.dpf_readings()[0].responder(), "7E8");
+        assert_eq!(replay.dpf_readings()[0].reading().value(), 12.72);
+        assert_eq!(replay.dpf_readings()[0].reading().unit(), "g");
+        assert!(replay.telemetry_full(8).unwrap().signals().next().is_none());
+        assert!(replay.issues().is_empty());
+    }
+
+    #[test]
+    fn dpf_replay_reports_unsupported_candidate_without_telemetry() {
+        let replay = CaptureReplay::from_capture(&capture(vec![dpf_response(
+            "dpf.distance_since_regeneration",
+            vec![0x22, 0x11, 0x56],
+            Some("7E8"),
+            vec![0x62, 0x11, 0x56, 0x00, 0x01, 0x4f, 0xf3],
+            Some("7E8"),
+        )]));
+
+        assert!(replay.dpf_readings().is_empty());
+        assert!(replay
+            .issues()
+            .iter()
+            .any(|issue| issue.kind() == ReplayIssueKind::UnsupportedDpfCandidate));
+        assert!(replay.telemetry_full(8).unwrap().signals().next().is_none());
+    }
+
+    #[test]
+    fn dpf_replay_rejects_malformed_raw_evidence() {
+        let replay = CaptureReplay::from_capture(&capture(vec![dpf_response(
+            "dpf.soot_mass_calculated",
+            vec![0x22, 0x11, 0x4f],
+            Some("7E8"),
+            vec![0x62, 0x11, 0x4f, 0x04],
+            Some("7E8"),
+        )]));
+
+        assert!(replay.dpf_readings().is_empty());
+        assert!(replay
+            .issues()
+            .iter()
+            .any(|issue| issue.kind() == ReplayIssueKind::MalformedDpfEvidence));
+        assert!(replay.telemetry_full(8).unwrap().signals().next().is_none());
+    }
+
+    #[test]
+    fn dpf_replay_keeps_a_negative_uds_response_distinct_from_malformed_evidence() {
+        let replay = CaptureReplay::from_capture(&capture(vec![dpf_response(
+            "dpf.soot_mass_calculated",
+            vec![0x22, 0x11, 0x4f],
+            Some("7E8"),
+            vec![0x7f, 0x22, 0x31],
+            Some("7E8"),
+        )]));
+
+        assert!(replay.dpf_readings().is_empty());
+        assert!(replay
+            .issues()
+            .iter()
+            .any(|issue| issue.kind() == ReplayIssueKind::NegativeDpfResponse));
+        assert!(replay.telemetry_full(8).unwrap().signals().next().is_none());
+    }
+
+    #[test]
+    fn dpf_replay_rejects_responder_selection_not_in_evidence() {
+        let replay = CaptureReplay::from_capture(&capture(vec![dpf_response(
+            "dpf.soot_mass_calculated",
+            vec![0x22, 0x11, 0x4f],
+            Some("7E8"),
+            vec![0x62, 0x11, 0x4f, 0x04, 0xf8],
+            Some("7E9"),
+        )]));
+
+        assert!(replay.dpf_readings().is_empty());
+        assert!(replay
+            .issues()
+            .iter()
+            .any(|issue| issue.kind() == ReplayIssueKind::WrongResponderSelection));
+        assert!(replay.telemetry_full(8).unwrap().signals().next().is_none());
+    }
+
+    #[test]
+    fn unknown_dpf_semantic_is_not_replayed() {
+        let replay = CaptureReplay::from_capture(&capture(vec![dpf_response(
+            "dpf.ash_mass",
+            vec![0x22, 0x17, 0x8c],
+            Some("7E8"),
+            vec![0x62, 0x17, 0x8c, 0x00, 0x01],
+            Some("7E8"),
+        )]));
+
+        assert!(replay.dpf_readings().is_empty());
+        assert!(replay
+            .issues()
+            .iter()
+            .any(|issue| issue.kind() == ReplayIssueKind::UnsupportedDpfCandidate));
     }
 }

--- a/src/ea189.rs
+++ b/src/ea189.rs
@@ -139,6 +139,132 @@ impl Ea189DpfProbe {
     }
 }
 
+/// A value decoded from a Gate-A response using a still-experimental EA189
+/// hypothesis.  This type is deliberately separate from [`Ea189Profile`]: a
+/// successful decode does not promote a candidate into production knowledge.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Ea189ExperimentalDpfReading {
+    probe: Ea189DpfProbe,
+    value: f64,
+    unit: &'static str,
+    decoder: &'static str,
+}
+
+impl Ea189ExperimentalDpfReading {
+    pub const fn probe(self) -> Ea189DpfProbe {
+        self.probe
+    }
+
+    pub const fn semantic(self) -> &'static str {
+        self.probe.semantic()
+    }
+
+    pub const fn did(self) -> u16 {
+        self.probe.id()
+    }
+
+    pub const fn value(self) -> f64 {
+        self.value
+    }
+
+    pub const fn unit(self) -> &'static str {
+        self.unit
+    }
+
+    pub const fn decoder(self) -> &'static str {
+        self.decoder
+    }
+
+    /// Every reading returned by this module is experimental by construction.
+    pub const fn is_experimental(self) -> bool {
+        true
+    }
+}
+
+/// Errors from the closed experimental Gate-B decoder set.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Ea189DpfDecodeError {
+    UnsupportedProbe(Ea189DpfProbe),
+    MalformedPositiveResponse,
+    WrongDid { expected: u16, actual: u16 },
+}
+
+impl std::fmt::Display for Ea189DpfDecodeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedProbe(probe) => {
+                write!(
+                    formatter,
+                    "no experimental decoder for DID {:04X}",
+                    probe.id()
+                )
+            }
+            Self::MalformedPositiveResponse => {
+                formatter.write_str("malformed UDS positive DPF response")
+            }
+            Self::WrongDid { expected, actual } => write!(
+                formatter,
+                "UDS response DID {:04X} does not match requested DID {:04X}",
+                actual, expected
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Ea189DpfDecodeError {}
+
+/// Decode one exact, positive Gate-A response with an experimental hypothesis.
+///
+/// The accepted shape is exactly `62 <DID_hi> <DID_lo> <A> <B>`.  The three
+/// remaining Gate-A candidates have no decoder yet and are rejected.
+pub fn decode_experimental_dpf(
+    probe: Ea189DpfProbe,
+    response: &[u8],
+) -> Result<Ea189ExperimentalDpfReading, Ea189DpfDecodeError> {
+    let expected_did = probe.id();
+    if response.len() != 5 {
+        return Err(Ea189DpfDecodeError::MalformedPositiveResponse);
+    }
+    if response[0] != 0x62 {
+        return Err(Ea189DpfDecodeError::MalformedPositiveResponse);
+    }
+    let actual_did = u16::from_be_bytes([response[1], response[2]]);
+    if actual_did != expected_did {
+        return Err(Ea189DpfDecodeError::WrongDid {
+            expected: expected_did,
+            actual: actual_did,
+        });
+    }
+    let data = u16::from_be_bytes([response[3], response[4]]);
+    let (value, unit, decoder) = match probe {
+        Ea189DpfProbe::SootMassCalculated => {
+            (data as f64 / 100.0, "g", "BE u16 / 100 (experimental)")
+        }
+        Ea189DpfProbe::SootMassMeasured => (
+            i16::from_be_bytes([response[3], response[4]]) as f64 / 100.0,
+            "g",
+            "BE i16 / 100 (experimental)",
+        ),
+        Ea189DpfProbe::PreDpfTemperature | Ea189DpfProbe::PostDpfTemperature => (
+            (i32::from(data) - 2731) as f64 / 10.0,
+            "°C",
+            "(BE u16 - 2731) / 10 (Kelvin hypothesis; experimental)",
+        ),
+        Ea189DpfProbe::DistanceSinceRegeneration
+        | Ea189DpfProbe::TimeSinceRegeneration
+        | Ea189DpfProbe::DifferentialPressure => {
+            return Err(Ea189DpfDecodeError::UnsupportedProbe(probe));
+        }
+    };
+
+    Ok(Ea189ExperimentalDpfReading {
+        probe,
+        value,
+        unit,
+        decoder,
+    })
+}
+
 /// Target-bound DPF probe input. Construction only accepts an engine
 /// `KnownEcu` scope, so a candidate cannot be detached into a vehicle-wide or
 /// functional operation.
@@ -454,6 +580,101 @@ mod tests {
 
     fn evidence() -> ProfileEvidence {
         ProfileEvidence::new(provenance("sanitized hardware fixture"), "fixture-01").unwrap()
+    }
+
+    #[test]
+    fn experimental_decoder_uses_unsigned_calculated_soot() {
+        let reading = decode_experimental_dpf(
+            Ea189DpfProbe::SootMassCalculated,
+            &[0x62, 0x11, 0x4f, 0x04, 0xf8],
+        )
+        .unwrap();
+
+        assert_eq!(reading.semantic(), "dpf.soot_mass_calculated");
+        assert_eq!(reading.did(), 0x114f);
+        assert_eq!(reading.value(), 12.72);
+        assert_eq!(reading.unit(), "g");
+        assert!(reading.is_experimental());
+    }
+
+    #[test]
+    fn experimental_decoder_preserves_negative_measured_soot() {
+        let reading = decode_experimental_dpf(
+            Ea189DpfProbe::SootMassMeasured,
+            &[0x62, 0x11, 0x4e, 0xfe, 0xfc],
+        )
+        .unwrap();
+
+        assert_eq!(reading.value(), -2.6);
+        assert_eq!(reading.unit(), "g");
+        assert!(reading.decoder().contains("i16"));
+    }
+
+    #[test]
+    fn experimental_decoder_applies_temperature_hypothesis_to_both_candidates() {
+        for probe in [
+            Ea189DpfProbe::PreDpfTemperature,
+            Ea189DpfProbe::PostDpfTemperature,
+        ] {
+            let reading = decode_experimental_dpf(
+                probe,
+                &[0x62, (probe.id() >> 8) as u8, probe.id() as u8, 0x0b, 0xb9],
+            )
+            .unwrap();
+            assert_eq!(reading.value(), 27.0);
+            assert_eq!(reading.unit(), "°C");
+            assert!(reading.is_experimental());
+        }
+    }
+
+    #[test]
+    fn experimental_decoder_rejects_undecoded_gate_a_candidates() {
+        for probe in [
+            Ea189DpfProbe::DistanceSinceRegeneration,
+            Ea189DpfProbe::TimeSinceRegeneration,
+            Ea189DpfProbe::DifferentialPressure,
+        ] {
+            assert_eq!(
+                decode_experimental_dpf(
+                    probe,
+                    &[0x62, (probe.id() >> 8) as u8, probe.id() as u8, 0x00, 0x01],
+                ),
+                Err(Ea189DpfDecodeError::UnsupportedProbe(probe))
+            );
+        }
+    }
+
+    #[test]
+    fn experimental_decoder_requires_exact_positive_two_byte_payload() {
+        let probe = Ea189DpfProbe::SootMassCalculated;
+        for response in [
+            vec![],
+            vec![0x62],
+            vec![0x62, 0x11],
+            vec![0x62, 0x11, 0x4f],
+            vec![0x62, 0x11, 0x4f, 0x00],
+            vec![0x62, 0x11, 0x4f, 0x00, 0x01, 0x00],
+            vec![0x61, 0x11, 0x4f, 0x00, 0x01],
+        ] {
+            assert_eq!(
+                decode_experimental_dpf(probe, &response),
+                Err(Ea189DpfDecodeError::MalformedPositiveResponse)
+            );
+        }
+    }
+
+    #[test]
+    fn experimental_decoder_rejects_wrong_did() {
+        assert_eq!(
+            decode_experimental_dpf(
+                Ea189DpfProbe::SootMassCalculated,
+                &[0x62, 0x11, 0x4e, 0x00, 0x01],
+            ),
+            Err(Ea189DpfDecodeError::WrongDid {
+                expected: 0x114f,
+                actual: 0x114e,
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- decode four closed EA189 DPF hypotheses offline only and mark every reading experimental
- retain distance, time, and differential pressure as explicitly undecoded evidence
- replay responder-selected UDS evidence without adding it to generic telemetry

## Validation
- `cargo +1.98.0 fmt --check`
- `cargo +1.98.0 test --locked`
- `cargo +1.98.0 clippy --all-targets -- -D warnings`
- `cargo +1.98.0 build --locked`

Refs #14