### PR TITLE
Add offline DPF capture report

### DIFF
--- a/src/dpf_report.rs
+++ b/src/dpf_report.rs
@@ -1,0 +1,219 @@
+//! Small, privacy-safe summaries of experimentally decoded DPF replay data.
+
+use std::collections::BTreeMap;
+
+use crate::capture_replay::CaptureReplay;
+
+/// One per-semantic summary of successful DPF replay readings.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DpfSummary {
+    semantic: &'static str,
+    count: usize,
+    first_value: f64,
+    last_value: f64,
+    min: f64,
+    max: f64,
+    delta: f64,
+    unit: &'static str,
+}
+
+impl DpfSummary {
+    pub fn semantic(&self) -> &'static str {
+        self.semantic
+    }
+
+    pub const fn count(&self) -> usize {
+        self.count
+    }
+
+    pub const fn first_value(&self) -> f64 {
+        self.first_value
+    }
+
+    pub const fn last_value(&self) -> f64 {
+        self.last_value
+    }
+
+    pub const fn min(&self) -> f64 {
+        self.min
+    }
+
+    pub const fn max(&self) -> f64 {
+        self.max
+    }
+
+    pub const fn delta(&self) -> f64 {
+        self.delta
+    }
+
+    pub const fn unit(&self) -> &'static str {
+        self.unit
+    }
+}
+
+/// The privacy-safe, offline view of a capture's successful DPF decodes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DpfReport {
+    duration_us: u64,
+    summaries: Vec<DpfSummary>,
+}
+
+impl DpfReport {
+    /// Summarize only successful DPF readings from a deterministic replay.
+    pub fn from_replay(replay: &CaptureReplay) -> Self {
+        Self::from_replays([replay])
+    }
+
+    /// Summarize captures in the caller-provided order.  Captures are
+    /// snapshots, not one continuous timestamped DPF stream.
+    pub fn from_replays<'a>(replays: impl IntoIterator<Item = &'a CaptureReplay>) -> Self {
+        let mut accumulators = BTreeMap::new();
+        let mut duration_us = 0_u64;
+        for replay in replays {
+            duration_us = duration_us.saturating_add(replay.duration_us());
+            for replay_reading in replay.dpf_readings() {
+                let reading = replay_reading.reading();
+                accumulators
+                    .entry(reading.semantic())
+                    .and_modify(|summary: &mut Accumulator| summary.push(reading.value()))
+                    .or_insert_with(|| Accumulator::new(reading.value(), reading.unit()));
+            }
+        }
+
+        Self {
+            duration_us,
+            summaries: accumulators
+                .into_iter()
+                .map(|(semantic, accumulator)| accumulator.finish(semantic))
+                .collect(),
+        }
+    }
+
+    pub const fn duration_us(&self) -> u64 {
+        self.duration_us
+    }
+
+    pub fn summaries(&self) -> &[DpfSummary] {
+        &self.summaries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.summaries.is_empty()
+    }
+}
+
+struct Accumulator {
+    count: usize,
+    first_value: f64,
+    last_value: f64,
+    min: f64,
+    max: f64,
+    unit: &'static str,
+}
+
+impl Accumulator {
+    fn new(value: f64, unit: &'static str) -> Self {
+        Self {
+            count: 1,
+            first_value: value,
+            last_value: value,
+            min: value,
+            max: value,
+            unit,
+        }
+    }
+
+    fn push(&mut self, value: f64) {
+        self.count += 1;
+        self.last_value = value;
+        self.min = self.min.min(value);
+        self.max = self.max.max(value);
+    }
+
+    fn finish(self, semantic: &'static str) -> DpfSummary {
+        DpfSummary {
+            semantic,
+            count: self.count,
+            first_value: self.first_value,
+            last_value: self.last_value,
+            min: self.min,
+            max: self.max,
+            delta: self.last_value - self.first_value,
+            unit: self.unit,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        capture_events::{CaptureEvent, ResponderEvidence},
+        jsonl_capture::{CaptureStatus, ParsedCapture},
+    };
+
+    fn dpf_response(value: [u8; 2]) -> CaptureEvent {
+        CaptureEvent::ResponsesObserved {
+            semantic: "dpf.soot_mass_calculated".into(),
+            request_payload: vec![0x22, 0x11, 0x4f],
+            responses: vec![ResponderEvidence {
+                responder: Some("7E8".into()),
+                payload: vec![0x62, 0x11, 0x4f, value[0], value[1]],
+            }],
+            selected_responder: Some("7E8".into()),
+            selection_error: None,
+        }
+    }
+
+    fn replay(events: Vec<CaptureEvent>) -> CaptureReplay {
+        CaptureReplay::from_capture(&ParsedCapture {
+            events,
+            status: CaptureStatus::Complete,
+        })
+    }
+
+    #[test]
+    fn summarizes_values_and_keeps_capture_duration() {
+        let report = DpfReport::from_replay(&replay(vec![
+            dpf_response([0x04, 0xe2]),
+            dpf_response([0x09, 0xc4]),
+            CaptureEvent::SessionStopped {
+                offset_us: 5_000_000,
+            },
+        ]));
+
+        assert_eq!(report.duration_us(), 5_000_000);
+        assert_eq!(report.summaries().len(), 1);
+        let summary = &report.summaries()[0];
+        assert_eq!(summary.semantic(), "dpf.soot_mass_calculated");
+        assert_eq!(summary.count(), 2);
+        assert_eq!(summary.first_value(), 12.5);
+        assert_eq!(summary.last_value(), 25.0);
+        assert_eq!(summary.min(), 12.5);
+        assert_eq!(summary.max(), 25.0);
+        assert_eq!(summary.delta(), 12.5);
+        assert_eq!(summary.unit(), "g");
+    }
+
+    #[test]
+    fn empty_replay_has_no_summaries() {
+        let report = DpfReport::from_replay(&replay(Vec::new()));
+
+        assert!(report.is_empty());
+        assert!(report.summaries().is_empty());
+        assert_eq!(report.duration_us(), 0);
+    }
+
+    #[test]
+    fn multiple_snapshots_keep_input_order_for_first_last_and_delta() {
+        let first = replay(vec![dpf_response([0x01, 0x90])]);
+        let last = replay(vec![dpf_response([0x01, 0xf4])]);
+
+        let report = DpfReport::from_replays([&first, &last]);
+
+        let summary = &report.summaries()[0];
+        assert_eq!(summary.first_value(), 4.0);
+        assert_eq!(summary.last_value(), 5.0);
+        assert_eq!(summary.delta(), 1.0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod capture_report;
 pub mod capture_tui;
 pub mod compound_fact;
 pub mod diagnostic_job;
+pub mod dpf_report;
 pub mod dtc;
 pub mod ea189;
 pub mod evidence;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use obdentic::{
         CaptureEvent, CaptureSubscription, DiagnosticJobStepStatus, DtcObservationFact,
         DtcTransportOutcome, SubscriptionFilterOutcome,
     },
+    capture_replay::CaptureReplay,
     capture_report, capture_tui,
     diagnostic_job::{DiagnosticJob, DiagnosticScope, JobStatus, KnownTarget},
     dtc, hex, jsonl_capture,
@@ -40,7 +41,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic diagnose ea189.dpf.probe --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
+const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic diagnose ea189.dpf.probe --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic capture dpf-report <capture.jsonl>... | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
 
 #[derive(Debug, PartialEq, Eq)]
 enum Command {
@@ -75,6 +76,7 @@ enum Command {
     },
     CaptureInspect(String),
     CaptureCapability(String),
+    CaptureDpfReport(Vec<String>),
     Read {
         request: ReadRequest,
         adapter_id: String,
@@ -203,6 +205,7 @@ async fn run() -> Result<(), String> {
                 print!("{}", capture_report::render_capability(&path, &capture));
                 Ok(())
             }
+            Command::CaptureDpfReport(paths) => run_capture_dpf_report(&paths),
             Command::Demo => {
                 show(&demo().await?);
                 Ok(())
@@ -1969,6 +1972,71 @@ fn load_layout(path: Option<&str>) -> Result<tui::DashboardLayout, String> {
     )
 }
 
+fn run_capture_dpf_report(paths: &[String]) -> Result<(), String> {
+    let mut replays = Vec::with_capacity(paths.len());
+    for path in paths {
+        replays.push(CaptureReplay::from_capture(&jsonl_capture::read(
+            Path::new(path),
+        )?));
+    }
+
+    for (path, replay) in paths.iter().zip(&replays) {
+        print!(
+            "{}",
+            render_dpf_report(
+                path,
+                &obdentic::dpf_report::DpfReport::from_replay(replay),
+                "Capture duration",
+            )
+        );
+    }
+    if replays.len() > 1 {
+        print!(
+            "{}",
+            render_dpf_report(
+                "across input order",
+                &obdentic::dpf_report::DpfReport::from_replays(&replays),
+                "Accumulated capture duration",
+            )
+        );
+    }
+    Ok(())
+}
+
+fn render_dpf_report(
+    label: &str,
+    report: &obdentic::dpf_report::DpfReport,
+    duration_label: &str,
+) -> String {
+    let mut output = format!(
+        "DPF report: {label}\nStatus: vehicle-specific experimental replay\n{duration_label}: {:.3} s\n",
+        report.duration_us() as f64 / 1_000_000.0,
+    );
+    if report.is_empty() {
+        output.push_str("No decodable experimental DPF readings.\n\n");
+        return output;
+    }
+    output.push_str("Signals\n");
+    for summary in report.summaries() {
+        output.push_str(&format!(
+            "  {}\n    samples: {}; first/last: {:.3} / {:.3} {}; delta: {:+.3}; range: {:.3} .. {:.3}\n",
+            summary.semantic(),
+            summary.count(),
+            summary.first_value(),
+            summary.last_value(),
+            summary.unit(),
+            summary.delta(),
+            summary.min(),
+            summary.max(),
+        ));
+    }
+    if label == "across input order" {
+        output.push_str("Input order compares snapshots; it is not a continuous DPF timeline.\n");
+    }
+    output.push('\n');
+    output
+}
+
 fn parse_command(args: &[String]) -> Result<Command, String> {
     match args {
         [command] if command == "signals" => Ok(Command::Signals),
@@ -2070,6 +2138,11 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
         }
         [command, action, path] if command == "capture" && action == "capability" => {
             Ok(Command::CaptureCapability(path.clone()))
+        }
+        [command, action, paths @ ..]
+            if command == "capture" && action == "dpf-report" && !paths.is_empty() =>
+        {
+            Ok(Command::CaptureDpfReport(paths.to_vec()))
         }
         [command, path] if command == "replay" => Ok(Command::Replay(path.clone())),
         [command, action, name, path]
@@ -2452,6 +2525,18 @@ mod tests {
         assert_eq!(
             parse_command(&args(&["capture", "capability", "capture.jsonl"])),
             Ok(Command::CaptureCapability("capture.jsonl".into()))
+        );
+        assert_eq!(
+            parse_command(&args(&[
+                "capture",
+                "dpf-report",
+                "drive.jsonl",
+                "idle.jsonl",
+            ])),
+            Ok(Command::CaptureDpfReport(vec![
+                "drive.jsonl".into(),
+                "idle.jsonl".into(),
+            ]))
         );
         assert_eq!(
             parse_command(&args(&[


### PR DESCRIPTION
## Summary
- add `obdentic capture dpf-report <capture.jsonl>...`
- summarize only experimental DPF replay values: samples, first/last, delta, and range
- compare multiple capture snapshots in caller-provided order without inventing a continuous timeline

## Privacy and safety
- no raw TX/RX, VIN, adapter identifiers, or vehicle requests are emitted
- the report remains explicitly vehicle-specific and experimental

## Checks
- cargo fmt --check
- cargo test --locked
- cargo clippy --all-targets -- -D warnings
- cargo build --locked

Refs #14