### PR TITLE
Add bounded EA189 DPF capture trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,25 @@ cargo run -- capture inspect evidence/drive.jsonl
 cargo run -- capture capability evidence/drive.jsonl
 ```
 
+For a longer, read-only EA189 DPF trace, OBDentic repeats only the closed
+seven-DID probe on one persistent diagnostic session. The interval is a pause
+after each complete cycle; Ctrl-C stops after the active bounded read and
+flushes the JSONL capture.
+
+```sh
+cargo run -- capture \
+  --adapter "$ADAPTER_UUID" \
+  --profile ea189-dpf \
+  --record evidence/dpf-trace.jsonl \
+  --cycles 120 \
+  --interval-seconds 60
+
+cargo run -- capture dpf-report evidence/dpf-trace.jsonl
+```
+
+The trace records raw responder evidence and monotonic response offsets. Its
+decoded DPF report remains vehicle-specific and experimental.
+
 To validate the seven already advertised, standards-derived Mode 01 additions
 without overbooking the conservative session budget, use the dedicated profile:
 

--- a/src/capture_events.rs
+++ b/src/capture_events.rs
@@ -199,6 +199,9 @@ pub enum CaptureEvent {
     /// Preserves every normalized response before semantic selection. This
     /// event may accompany either a successful read or an explicit ambiguity.
     ResponsesObserved {
+        /// Monotonic offset from the capture session start. `None` denotes a
+        /// legacy event that predates response-level timing evidence.
+        offset_us: Option<CaptureTimeUs>,
         semantic: String,
         request_payload: Vec<u8>,
         responses: Vec<ResponderEvidence>,
@@ -353,6 +356,27 @@ impl CaptureEvent {
         selected_responder: Option<String>,
         selection_error: Option<String>,
     ) -> Result<Self, String> {
+        Self::responses_observed_with_offset(
+            semantic,
+            request_payload,
+            responses,
+            selected_responder,
+            selection_error,
+            None,
+        )
+    }
+
+    /// Build response evidence with an optional monotonic session offset.
+    /// Keeping the offset optional lets callers continue producing captures
+    /// compatible with older adapters and replay those records unchanged.
+    pub fn responses_observed_with_offset(
+        semantic: impl Into<String>,
+        request_payload: Vec<u8>,
+        responses: Vec<ResponderEvidence>,
+        selected_responder: Option<String>,
+        selection_error: Option<String>,
+        offset_us: Option<CaptureTimeUs>,
+    ) -> Result<Self, String> {
         if request_payload.is_empty() {
             return Err("observed response request payload must not be empty".into());
         }
@@ -363,12 +387,32 @@ impl CaptureEvent {
             return Err("observed response payload must not be empty".into());
         }
         Ok(Self::ResponsesObserved {
+            offset_us,
             semantic: semantic.into(),
             request_payload,
             responses,
             selected_responder,
             selection_error,
         })
+    }
+
+    /// Build response evidence at a known capture offset.
+    pub fn responses_observed_at(
+        semantic: impl Into<String>,
+        request_payload: Vec<u8>,
+        responses: Vec<ResponderEvidence>,
+        selected_responder: Option<String>,
+        selection_error: Option<String>,
+        offset_us: CaptureTimeUs,
+    ) -> Result<Self, String> {
+        Self::responses_observed_with_offset(
+            semantic,
+            request_payload,
+            responses,
+            selected_responder,
+            selection_error,
+            Some(offset_us),
+        )
     }
 
     /// Copy a completed read into an owned event without rebuilding its
@@ -891,6 +935,44 @@ mod tests {
         )
         .is_err());
         assert!(ResponderEvidence::new(Some("7E8".into()), Vec::new()).is_err());
+    }
+
+    #[test]
+    fn response_observation_constructor_preserves_optional_offset() {
+        let response = ResponderEvidence::new(Some("7E8".into()), vec![0x41, 0x0c]).unwrap();
+        assert_eq!(
+            CaptureEvent::responses_observed(
+                "engine.rpm",
+                vec![0x01, 0x0c],
+                vec![response.clone()],
+                Some("7E8".into()),
+                None,
+            )
+            .unwrap(),
+            CaptureEvent::ResponsesObserved {
+                offset_us: None,
+                semantic: "engine.rpm".into(),
+                request_payload: vec![0x01, 0x0c],
+                responses: vec![response.clone()],
+                selected_responder: Some("7E8".into()),
+                selection_error: None,
+            }
+        );
+        assert!(matches!(
+            CaptureEvent::responses_observed_at(
+                "engine.rpm",
+                vec![0x01, 0x0c],
+                vec![response],
+                Some("7E8".into()),
+                None,
+                42,
+            )
+            .unwrap(),
+            CaptureEvent::ResponsesObserved {
+                offset_us: Some(42),
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/src/capture_replay.rs
+++ b/src/capture_replay.rs
@@ -58,6 +58,7 @@ impl ReplayIssue {
 pub struct DpfReplayReading {
     reading: Ea189ExperimentalDpfReading,
     responder: String,
+    offset_us: Option<u64>,
 }
 
 impl DpfReplayReading {
@@ -67,6 +68,12 @@ impl DpfReplayReading {
 
     pub fn responder(&self) -> &str {
         &self.responder
+    }
+
+    /// Monotonic session offset when recorded by a new capture. `None` is
+    /// preserved for legacy response evidence without timing metadata.
+    pub const fn offset_us(&self) -> Option<u64> {
+        self.offset_us
     }
 }
 
@@ -166,16 +173,20 @@ impl CaptureReplay {
                 }
                 CaptureEvent::ReadFailed { .. } => {}
                 CaptureEvent::ResponsesObserved {
+                    offset_us,
                     semantic,
                     request_payload,
                     responses,
                     selected_responder,
                     selection_error,
                 } => {
+                    if let Some(offset_us) = offset_us {
+                        duration_us = duration_us.max(*offset_us);
+                    }
                     let mut state = DpfReplayState {
                         readings: &mut dpf_readings,
                         issues: &mut issues,
-                        at_us: duration_us,
+                        at_us: offset_us.unwrap_or(duration_us),
                     };
                     replay_dpf_responses(
                         semantic,
@@ -183,6 +194,7 @@ impl CaptureReplay {
                         responses,
                         selected_responder,
                         selection_error,
+                        *offset_us,
                         &mut state,
                     );
                 }
@@ -271,6 +283,7 @@ fn replay_dpf_responses(
     responses: &[ResponderEvidence],
     selected_responder: &Option<String>,
     selection_error: &Option<String>,
+    offset_us: Option<u64>,
     state: &mut DpfReplayState<'_>,
 ) {
     if !is_dpf_semantic(semantic) {
@@ -369,6 +382,7 @@ fn replay_dpf_responses(
         Ok(reading) => state.readings.push(DpfReplayReading {
             reading,
             responder: selected_responder.to_owned(),
+            offset_us,
         }),
         Err(error) => {
             let alternate_decodes = responses.iter().any(|candidate| {
@@ -469,7 +483,26 @@ mod tests {
         payload: Vec<u8>,
         selected_responder: Option<&str>,
     ) -> CaptureEvent {
+        dpf_response_at(
+            semantic,
+            request,
+            responder,
+            payload,
+            selected_responder,
+            None,
+        )
+    }
+
+    fn dpf_response_at(
+        semantic: &str,
+        request: Vec<u8>,
+        responder: Option<&str>,
+        payload: Vec<u8>,
+        selected_responder: Option<&str>,
+        offset_us: Option<u64>,
+    ) -> CaptureEvent {
         CaptureEvent::ResponsesObserved {
+            offset_us,
             semantic: semantic.into(),
             request_payload: request,
             responses: vec![ResponderEvidence {
@@ -623,6 +656,40 @@ mod tests {
         assert_eq!(replay.dpf_readings()[0].reading().unit(), "g");
         assert!(replay.telemetry_full(8).unwrap().signals().next().is_none());
         assert!(replay.issues().is_empty());
+    }
+
+    #[test]
+    fn dpf_replay_preserves_response_offset_and_uses_it_for_duration() {
+        let replay = CaptureReplay::from_capture(&capture(vec![
+            dpf_response_at(
+                "dpf.soot_mass_calculated",
+                vec![0x22, 0x11, 0x4f],
+                Some("7E8"),
+                vec![0x62, 0x11, 0x4f, 0x04, 0xf8],
+                Some("7E8"),
+                Some(4_000_001),
+            ),
+            CaptureEvent::SessionStopped {
+                offset_us: 5_000_000,
+            },
+        ]));
+
+        assert_eq!(replay.dpf_readings().len(), 1);
+        assert_eq!(replay.dpf_readings()[0].offset_us(), Some(4_000_001));
+        assert_eq!(replay.duration_us(), 5_000_000);
+    }
+
+    #[test]
+    fn legacy_dpf_replay_keeps_missing_response_offset() {
+        let replay = CaptureReplay::from_capture(&capture(vec![dpf_response(
+            "dpf.soot_mass_calculated",
+            vec![0x22, 0x11, 0x4f],
+            Some("7E8"),
+            vec![0x62, 0x11, 0x4f, 0x04, 0xf8],
+            Some("7E8"),
+        )]));
+
+        assert_eq!(replay.dpf_readings()[0].offset_us(), None);
     }
 
     #[test]

--- a/src/capture_tui.rs
+++ b/src/capture_tui.rs
@@ -147,12 +147,16 @@ impl Timeline {
                     ),
                 ),
                 CaptureEvent::ResponsesObserved {
+                    offset_us,
                     semantic,
                     request_payload,
                     responses,
                     selected_responder,
                     selection_error,
                 } => {
+                    let observed_at_us = offset_us.unwrap_or(clock_us);
+                    clock_us = clock_us.max(observed_at_us);
+                    timeline.duration_us = timeline.duration_us.max(observed_at_us);
                     let responders = responses
                         .iter()
                         .map(|response| {
@@ -165,7 +169,7 @@ impl Timeline {
                         .collect::<Vec<_>>()
                         .join(" | ");
                     timeline.push(
-                        clock_us,
+                        observed_at_us,
                         "responses",
                         Some(semantic.clone()),
                         format!(

--- a/src/dpf_report.rs
+++ b/src/dpf_report.rs
@@ -15,6 +15,8 @@ pub struct DpfSummary {
     max: f64,
     delta: f64,
     unit: &'static str,
+    first_offset_us: Option<u64>,
+    last_offset_us: Option<u64>,
 }
 
 impl DpfSummary {
@@ -49,6 +51,14 @@ impl DpfSummary {
     pub const fn unit(&self) -> &'static str {
         self.unit
     }
+
+    pub const fn first_offset_us(&self) -> Option<u64> {
+        self.first_offset_us
+    }
+
+    pub const fn last_offset_us(&self) -> Option<u64> {
+        self.last_offset_us
+    }
 }
 
 /// The privacy-safe, offline view of a capture's successful DPF decodes.
@@ -61,12 +71,19 @@ pub struct DpfReport {
 impl DpfReport {
     /// Summarize only successful DPF readings from a deterministic replay.
     pub fn from_replay(replay: &CaptureReplay) -> Self {
-        Self::from_replays([replay])
+        Self::from_replays_with_offsets([replay], true)
     }
 
     /// Summarize captures in the caller-provided order.  Captures are
     /// snapshots, not one continuous timestamped DPF stream.
     pub fn from_replays<'a>(replays: impl IntoIterator<Item = &'a CaptureReplay>) -> Self {
+        Self::from_replays_with_offsets(replays, false)
+    }
+
+    fn from_replays_with_offsets<'a>(
+        replays: impl IntoIterator<Item = &'a CaptureReplay>,
+        preserve_offsets: bool,
+    ) -> Self {
         let mut accumulators = BTreeMap::new();
         let mut duration_us = 0_u64;
         for replay in replays {
@@ -75,8 +92,23 @@ impl DpfReport {
                 let reading = replay_reading.reading();
                 accumulators
                     .entry(reading.semantic())
-                    .and_modify(|summary: &mut Accumulator| summary.push(reading.value()))
-                    .or_insert_with(|| Accumulator::new(reading.value(), reading.unit()));
+                    .and_modify(|summary: &mut Accumulator| {
+                        summary.push(
+                            reading.value(),
+                            preserve_offsets
+                                .then(|| replay_reading.offset_us())
+                                .flatten(),
+                        )
+                    })
+                    .or_insert_with(|| {
+                        Accumulator::new(
+                            reading.value(),
+                            reading.unit(),
+                            preserve_offsets
+                                .then(|| replay_reading.offset_us())
+                                .flatten(),
+                        )
+                    });
             }
         }
 
@@ -109,10 +141,12 @@ struct Accumulator {
     min: f64,
     max: f64,
     unit: &'static str,
+    first_offset_us: Option<u64>,
+    last_offset_us: Option<u64>,
 }
 
 impl Accumulator {
-    fn new(value: f64, unit: &'static str) -> Self {
+    fn new(value: f64, unit: &'static str, offset_us: Option<u64>) -> Self {
         Self {
             count: 1,
             first_value: value,
@@ -120,14 +154,22 @@ impl Accumulator {
             min: value,
             max: value,
             unit,
+            first_offset_us: offset_us,
+            last_offset_us: offset_us,
         }
     }
 
-    fn push(&mut self, value: f64) {
+    fn push(&mut self, value: f64, offset_us: Option<u64>) {
         self.count += 1;
         self.last_value = value;
         self.min = self.min.min(value);
         self.max = self.max.max(value);
+        if offset_us.is_none() {
+            self.first_offset_us = None;
+            self.last_offset_us = None;
+        } else if self.last_offset_us.is_some() {
+            self.last_offset_us = offset_us;
+        }
     }
 
     fn finish(self, semantic: &'static str) -> DpfSummary {
@@ -140,6 +182,8 @@ impl Accumulator {
             max: self.max,
             delta: self.last_value - self.first_value,
             unit: self.unit,
+            first_offset_us: self.first_offset_us,
+            last_offset_us: self.last_offset_us,
         }
     }
 }
@@ -154,6 +198,7 @@ mod tests {
 
     fn dpf_response(value: [u8; 2]) -> CaptureEvent {
         CaptureEvent::ResponsesObserved {
+            offset_us: None,
             semantic: "dpf.soot_mass_calculated".into(),
             request_payload: vec![0x22, 0x11, 0x4f],
             responses: vec![ResponderEvidence {
@@ -215,5 +260,26 @@ mod tests {
         assert_eq!(summary.first_value(), 4.0);
         assert_eq!(summary.last_value(), 5.0);
         assert_eq!(summary.delta(), 1.0);
+    }
+
+    #[test]
+    fn one_timed_capture_keeps_per_signal_offsets() {
+        let event = CaptureEvent::responses_observed_at(
+            "dpf.soot_mass_calculated",
+            vec![0x22, 0x11, 0x4f],
+            vec![
+                ResponderEvidence::new(Some("7E8".into()), vec![0x62, 0x11, 0x4f, 0x04, 0xe2])
+                    .unwrap(),
+            ],
+            Some("7E8".into()),
+            None,
+            12_345_678,
+        )
+        .unwrap();
+
+        let report = DpfReport::from_replay(&replay(vec![event]));
+
+        assert_eq!(report.summaries()[0].first_offset_us(), Some(12_345_678));
+        assert_eq!(report.summaries()[0].last_offset_us(), Some(12_345_678));
     }
 }

--- a/src/jsonl_capture.rs
+++ b/src/jsonl_capture.rs
@@ -193,6 +193,7 @@ fn event_line(sequence: u64, event: &CaptureEvent) -> Result<String, String> {
             push_string(&mut object, &hex(response_payload));
         }
         CaptureEvent::ResponsesObserved {
+            offset_us,
             semantic,
             request_payload,
             responses,
@@ -201,6 +202,8 @@ fn event_line(sequence: u64, event: &CaptureEvent) -> Result<String, String> {
         } => {
             object.push_str("\"responses_observed\",\"sequence\":");
             object.push_str(&sequence.to_string());
+            object.push_str(",\"offset_us\":");
+            push_option_u64(&mut object, *offset_us);
             object.push_str(",\"semantic\":");
             push_string(&mut object, semantic);
             object.push_str(",\"request_payload\":");
@@ -619,6 +622,7 @@ pub fn read(path: &Path) -> Result<ParsedCapture, String> {
 
     let mut events = Vec::new();
     let mut expected_sequence = 0_u64;
+    let mut last_response_offset_us = None;
     let mut stopped = false;
     for (line_number, line) in lines.enumerate() {
         let line_number = line_number + 2;
@@ -637,6 +641,16 @@ pub fn read(path: &Path) -> Result<ParsedCapture, String> {
             .checked_add(1)
             .ok_or_else(|| format!("line {line_number}: sequence exhausted"))?;
         let event = parse_event(&object, line_number)?;
+        if let CaptureEvent::ResponsesObserved {
+            offset_us: Some(offset_us),
+            ..
+        } = &event
+        {
+            if last_response_offset_us.is_some_and(|last| *offset_us < last) {
+                return Err(format!("line {line_number}: non-monotonic response offset"));
+            }
+            last_response_offset_us = Some(*offset_us);
+        }
         if matches!(event, CaptureEvent::SessionStopped { .. }) {
             if stopped {
                 return Err(format!(
@@ -798,19 +812,35 @@ fn parse_event(object: &Object, line_number: usize) -> Result<CaptureEvent, Stri
             .map_err(|error| format!("line {line_number}: {error}"))
         }
         "responses_observed" => {
+            let has_offset = object.contains_key("offset_us");
             fields_exact(
                 object,
-                &[
-                    "schema",
-                    "version",
-                    "type",
-                    "sequence",
-                    "semantic",
-                    "request_payload",
-                    "responses",
-                    "selected_responder",
-                    "selection_error",
-                ],
+                if has_offset {
+                    &[
+                        "schema",
+                        "version",
+                        "type",
+                        "sequence",
+                        "offset_us",
+                        "semantic",
+                        "request_payload",
+                        "responses",
+                        "selected_responder",
+                        "selection_error",
+                    ]
+                } else {
+                    &[
+                        "schema",
+                        "version",
+                        "type",
+                        "sequence",
+                        "semantic",
+                        "request_payload",
+                        "responses",
+                        "selected_responder",
+                        "selection_error",
+                    ]
+                },
                 line_number,
             )?;
             let responses = match object.get("responses") {
@@ -820,7 +850,7 @@ fn parse_event(object: &Object, line_number: usize) -> Result<CaptureEvent, Stri
                     .collect::<Result<Vec<_>, _>>()?,
                 _ => return Err(format!("line {line_number}: responses must be an array")),
             };
-            CaptureEvent::responses_observed(
+            CaptureEvent::responses_observed_with_offset(
                 string_field(object, "semantic", line_number)?,
                 parse_hex(
                     &string_field(object, "request_payload", line_number)?,
@@ -829,6 +859,11 @@ fn parse_event(object: &Object, line_number: usize) -> Result<CaptureEvent, Stri
                 responses,
                 optional_string_field(object, "selected_responder", line_number)?,
                 optional_string_field(object, "selection_error", line_number)?,
+                if has_offset {
+                    optional_u64_field(object, "offset_us", line_number)?
+                } else {
+                    None
+                },
             )
             .map_err(|error| format!("line {line_number}: {error}"))
         }
@@ -2375,6 +2410,61 @@ mod tests {
                 response_payload: vec![0x41, 0x00, 0x80, 0x00, 0x00, 0x01],
             }]
         );
+        fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn response_offsets_round_trip_and_legacy_records_default_to_none() {
+        let path = temp_path("response-offset");
+        let expected = CaptureEvent::responses_observed_at(
+            "dpf.soot_mass_calculated",
+            vec![0x22, 0x11, 0x4f],
+            vec![crate::capture_events::ResponderEvidence::new(
+                Some("7E8".into()),
+                vec![0x62, 0x11, 0x4f, 0x04, 0xf8],
+            )
+            .unwrap()],
+            Some("7E8".into()),
+            None,
+            12_345_678,
+        )
+        .unwrap();
+        let (sender, writer) = start(&path).unwrap();
+        sender.send(expected.clone()).await.unwrap();
+        finish(sender, writer).await;
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("\"offset_us\":12345678"));
+        assert_eq!(read_events(&path).unwrap(), vec![expected]);
+        fs::remove_file(path).unwrap();
+
+        let path = temp_path("legacy-response-offset");
+        fs::write(
+            &path,
+            "{\"schema\":\"OBDENTIC-CAPTURE\",\"version\":1,\"type\":\"header\"}\n{\"schema\":\"OBDENTIC-CAPTURE\",\"version\":1,\"type\":\"responses_observed\",\"sequence\":0,\"semantic\":\"dpf.soot_mass_calculated\",\"request_payload\":\"22 11 4F\",\"responses\":[{\"responder\":\"7E8\",\"payload\":\"62 11 4F 04 F8\"}],\"selected_responder\":\"7E8\",\"selection_error\":null}\n",
+        )
+        .unwrap();
+        let events = read_events(&path).unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [CaptureEvent::ResponsesObserved {
+                offset_us: None,
+                ..
+            }]
+        ));
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn rejects_response_offsets_that_go_backwards() {
+        let path = temp_path("response-offset-order");
+        fs::write(
+            &path,
+            "{\"schema\":\"OBDENTIC-CAPTURE\",\"version\":1,\"type\":\"header\"}\n{\"schema\":\"OBDENTIC-CAPTURE\",\"version\":1,\"type\":\"responses_observed\",\"sequence\":0,\"offset_us\":20,\"semantic\":\"dpf.soot_mass_calculated\",\"request_payload\":\"22 11 4F\",\"responses\":[{\"responder\":\"7E8\",\"payload\":\"62 11 4F 04 F8\"}],\"selected_responder\":\"7E8\",\"selection_error\":null}\n{\"schema\":\"OBDENTIC-CAPTURE\",\"version\":1,\"type\":\"responses_observed\",\"sequence\":1,\"offset_us\":19,\"semantic\":\"dpf.soot_mass_calculated\",\"request_payload\":\"22 11 4F\",\"responses\":[{\"responder\":\"7E8\",\"payload\":\"62 11 4F 04 F8\"}],\"selected_responder\":\"7E8\",\"selection_error\":null}\n",
+        )
+        .unwrap();
+        assert!(read(&path)
+            .unwrap_err()
+            .contains("non-monotonic response offset"));
         fs::remove_file(path).unwrap();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic diagnose ea189.dpf.probe --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic capture dpf-report <capture.jsonl>... | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
+const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic diagnose ea189.dpf.probe --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture --adapter <CoreBluetooth UUID> --profile ea189-dpf --record <capture.jsonl> --cycles <1..=1440> --interval-seconds <>=30> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic capture dpf-report <capture.jsonl>... | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
 
 #[derive(Debug, PartialEq, Eq)]
 enum Command {
@@ -77,6 +77,12 @@ enum Command {
     CaptureInspect(String),
     CaptureCapability(String),
     CaptureDpfReport(Vec<String>),
+    CaptureEa189DpfTrace {
+        adapter_id: String,
+        recording: String,
+        cycles: u16,
+        interval: Duration,
+    },
     Read {
         request: ReadRequest,
         adapter_id: String,
@@ -206,6 +212,22 @@ async fn run() -> Result<(), String> {
                 Ok(())
             }
             Command::CaptureDpfReport(paths) => run_capture_dpf_report(&paths),
+            Command::CaptureEa189DpfTrace {
+                adapter_id,
+                recording,
+                cycles,
+                interval,
+            } => {
+                run_capture_ea189_dpf_trace(
+                    &adapter_id,
+                    Path::new(&recording),
+                    cycles,
+                    interval,
+                    &runtime,
+                    &mut runtime_state,
+                )
+                .await
+            }
             Command::Demo => {
                 show(&demo().await?);
                 Ok(())
@@ -1044,6 +1066,52 @@ async fn run_diagnose_ea189_dpf_probe(
     runtime: &RuntimeClient,
     state: &mut RuntimeState,
 ) -> Result<(), String> {
+    run_ea189_dpf_capture(
+        adapter_id,
+        recording,
+        "ea189.dpf.probe",
+        1,
+        None,
+        runtime,
+        state,
+    )
+    .await
+}
+
+async fn run_capture_ea189_dpf_trace(
+    adapter_id: &str,
+    recording: &Path,
+    cycles: u16,
+    interval: Duration,
+    runtime: &RuntimeClient,
+    state: &mut RuntimeState,
+) -> Result<(), String> {
+    println!("capture profile  ea189-dpf");
+    println!("capture cycles   {cycles}");
+    println!("capture interval {} s after each cycle", interval.as_secs());
+    println!("capture record   {}", recording.display());
+    println!("capture running  press Ctrl-C to stop after the active read");
+    run_ea189_dpf_capture(
+        adapter_id,
+        Some(recording),
+        "ea189.dpf.trace",
+        cycles,
+        Some(interval),
+        runtime,
+        state,
+    )
+    .await
+}
+
+async fn run_ea189_dpf_capture(
+    adapter_id: &str,
+    recording: Option<&Path>,
+    profile: &str,
+    cycles: u16,
+    interval: Option<Duration>,
+    runtime: &RuntimeClient,
+    state: &mut RuntimeState,
+) -> Result<(), String> {
     let started = Instant::now();
     let recorder = recording
         .map(jsonl_capture::JsonlRecorder::start)
@@ -1053,10 +1121,7 @@ async fn run_diagnose_ea189_dpf_probe(
         if sender.is_some() {
             emit_capture_event(
                 sender,
-                CaptureEvent::capture_started(
-                    Some(wallclock_ms()?),
-                    Some("ea189.dpf.probe".into()),
-                ),
+                CaptureEvent::capture_started(Some(wallclock_ms()?), Some(profile.into())),
             )
             .await?;
             apply_runtime_event(
@@ -1067,7 +1132,10 @@ async fn run_diagnose_ea189_dpf_probe(
             )
             .await?;
         }
-        run_diagnose_ea189_dpf_probe_inner(adapter_id, runtime, state, sender).await
+        run_diagnose_ea189_dpf_probe_inner(
+            adapter_id, runtime, state, sender, started, cycles, interval,
+        )
+        .await
     }
     .await;
     let inactive = if sender.is_some() {
@@ -1109,6 +1177,9 @@ async fn run_diagnose_ea189_dpf_probe_inner(
     runtime: &RuntimeClient,
     state: &mut RuntimeState,
     recorder: Option<&jsonl_capture::Sender>,
+    started: Instant,
+    cycles: u16,
+    interval: Option<Duration>,
 ) -> Result<(), String> {
     let mapping = cached_engine_mapping(adapter_id).await?;
     let target = mapping
@@ -1162,124 +1233,189 @@ async fn run_diagnose_ea189_dpf_probe_inner(
     emit_capture_event(recorder, CaptureEvent::diagnostic_job_started(&job)).await?;
 
     let mut recoverable = false;
-    for step in plan.steps() {
-        let probe = step
-            .dpf_probe()
-            .ok_or_else(|| "EA189 DPF plan contains a non-probe step".to_string())?;
-        match SafetyPolicy::read_only().authorize_activity(
-            Activity::Diagnose,
-            OperationRequest::ea189_dpf_probe(probe, job_target(&job)?),
-        ) {
-            Ok(Operation::Ea189DpfProbe(_)) => {}
-            Ok(_) => {
-                return Err("read-only safety policy returned the wrong EA189 operation".into())
-            }
-            Err(error) => return Err(error.to_string()),
+    let mut completed_cycles = 0_u16;
+    let mut cancelled = false;
+    let mut cancellation = interval.map(|_| {
+        tokio::spawn(async {
+            let _ = tokio::signal::ctrl_c().await;
+        })
+    });
+    while completed_cycles < cycles {
+        if cancellation
+            .as_ref()
+            .is_some_and(tokio::task::JoinHandle::is_finished)
+        {
+            cancelled = true;
+            break;
         }
-        let request = ble::TargetedDpfProbeRequest::from_mapping(probe, &mapping)?;
-        match prepared.read_dpf_probe(request).await {
-            Ok(responses) => {
-                let response = responses.as_slice().first().ok_or_else(|| {
-                    format!("{} returned no normalized response", probe.semantic())
-                })?;
-                let expected_responder = mapping.expected_responder().value();
-                let responder_matches = response
-                    .responder
-                    .as_ref()
-                    .is_some_and(|responder| Some(responder.as_str()) == expected_responder);
-                let status = if response.payload.starts_with(&[
-                    0x62,
-                    probe.request_bytes()[1],
-                    probe.request_bytes()[2],
-                ]) && responder_matches
-                {
-                    DiagnosticJobStepStatus::Success
-                } else {
-                    recoverable = true;
-                    DiagnosticJobStepStatus::Recoverable
+        if completed_cycles > 0 {
+            let delay = interval.expect("trace cycles require an interval");
+            println!("capture pause  {} s", delay.as_secs());
+            if let Some(cancellation) = &mut cancellation {
+                cancelled = tokio::select! {
+                    _ = tokio::time::sleep(delay) => false,
+                    _ = cancellation => true,
                 };
-                let selected = responder_matches.then(|| {
-                    response
+            } else {
+                tokio::time::sleep(delay).await;
+            }
+            if cancelled {
+                break;
+            }
+        }
+        if cycles > 1 {
+            println!("capture cycle  {}/{}", completed_cycles + 1, cycles);
+        }
+        for step in plan.steps() {
+            if cancellation
+                .as_ref()
+                .is_some_and(tokio::task::JoinHandle::is_finished)
+            {
+                cancelled = true;
+                break;
+            }
+            let probe = step
+                .dpf_probe()
+                .ok_or_else(|| "EA189 DPF plan contains a non-probe step".to_string())?;
+            match SafetyPolicy::read_only().authorize_activity(
+                Activity::Diagnose,
+                OperationRequest::ea189_dpf_probe(probe, job_target(&job)?),
+            ) {
+                Ok(Operation::Ea189DpfProbe(_)) => {}
+                Ok(_) => {
+                    return Err("read-only safety policy returned the wrong EA189 operation".into())
+                }
+                Err(error) => return Err(error.to_string()),
+            }
+            let request = ble::TargetedDpfProbeRequest::from_mapping(probe, &mapping)?;
+            match prepared.read_dpf_probe(request).await {
+                Ok(responses) => {
+                    let response = responses.as_slice().first().ok_or_else(|| {
+                        format!("{} returned no normalized response", probe.semantic())
+                    })?;
+                    let expected_responder = mapping.expected_responder().value();
+                    let responder_matches = response
                         .responder
                         .as_ref()
-                        .expect("matching responder is present")
-                        .as_str()
-                        .to_owned()
-                });
-                emit_capture_event(
-                    recorder,
-                    CaptureEvent::responses_observed(
+                        .is_some_and(|responder| Some(responder.as_str()) == expected_responder);
+                    let status = if response.payload.starts_with(&[
+                        0x62,
+                        probe.request_bytes()[1],
+                        probe.request_bytes()[2],
+                    ]) && responder_matches
+                    {
+                        DiagnosticJobStepStatus::Success
+                    } else {
+                        recoverable = true;
+                        DiagnosticJobStepStatus::Recoverable
+                    };
+                    let selected = responder_matches.then(|| {
+                        response
+                            .responder
+                            .as_ref()
+                            .expect("matching responder is present")
+                            .as_str()
+                            .to_owned()
+                    });
+                    emit_capture_event(
+                        recorder,
+                        CaptureEvent::responses_observed_at(
+                            probe.semantic(),
+                            probe.request_bytes().into(),
+                            responses.capture_evidence(),
+                            selected.clone(),
+                            (status != DiagnosticJobStepStatus::Success)
+                                .then_some("unexpected_or_negative_uds_response".into()),
+                            capture_offset_us(started)?,
+                        )?,
+                    )
+                    .await?;
+                    emit_capture_event(
+                        recorder,
+                        CaptureEvent::diagnostic_job_step(
+                            job.id().to_string(),
+                            step.sequence()
+                                .try_into()
+                                .map_err(|_| "EA189 DPF step index exceeds u64")?,
+                            0x22,
+                            selected.clone(),
+                            status,
+                            (status != DiagnosticJobStepStatus::Success)
+                                .then_some("negative_or_malformed_response".into()),
+                        )?,
+                    )
+                    .await?;
+                    println!(
+                        "probe\t{}\t{:04X}\t{}\t{}",
                         probe.semantic(),
-                        probe.request_bytes().into(),
-                        responses.capture_evidence(),
-                        selected.clone(),
-                        (status != DiagnosticJobStepStatus::Success)
-                            .then_some("unexpected_or_negative_uds_response".into()),
-                    )?,
-                )
-                .await?;
-                emit_capture_event(
-                    recorder,
-                    CaptureEvent::diagnostic_job_step(
-                        job.id().to_string(),
-                        step.sequence()
-                            .try_into()
-                            .map_err(|_| "EA189 DPF step index exceeds u64")?,
-                        0x22,
-                        selected.clone(),
-                        status,
-                        (status != DiagnosticJobStepStatus::Success)
-                            .then_some("negative_or_malformed_response".into()),
-                    )?,
-                )
-                .await?;
-                println!(
-                    "probe\t{}\t{:04X}\t{}\t{}",
-                    probe.semantic(),
-                    probe.id(),
-                    selected.unwrap_or_else(|| "unknown".into()),
-                    hex(&response.payload),
-                );
-            }
-            Err(error) => {
-                recoverable = true;
-                emit_capture_event(
-                    recorder,
-                    CaptureEvent::diagnostic_job_step(
-                        job.id().to_string(),
-                        step.sequence()
-                            .try_into()
-                            .map_err(|_| "EA189 DPF step index exceeds u64")?,
-                        0x22,
-                        None,
-                        DiagnosticJobStepStatus::Recoverable,
-                        Some(error.clone()),
-                    )?,
-                )
-                .await?;
-                println!(
-                    "probe\t{}\t{:04X}\terror\t{error}",
-                    probe.semantic(),
-                    probe.id()
-                );
+                        probe.id(),
+                        selected.unwrap_or_else(|| "unknown".into()),
+                        hex(&response.payload),
+                    );
+                }
+                Err(error) => {
+                    recoverable = true;
+                    emit_capture_event(
+                        recorder,
+                        CaptureEvent::diagnostic_job_step(
+                            job.id().to_string(),
+                            step.sequence()
+                                .try_into()
+                                .map_err(|_| "EA189 DPF step index exceeds u64")?,
+                            0x22,
+                            None,
+                            DiagnosticJobStepStatus::Recoverable,
+                            Some(error.clone()),
+                        )?,
+                    )
+                    .await?;
+                    println!(
+                        "probe\t{}\t{:04X}\terror\t{error}",
+                        probe.semantic(),
+                        probe.id()
+                    );
+                }
             }
         }
+        if cancelled {
+            break;
+        }
+        completed_cycles += 1;
     }
     let shutdown = prepared.shutdown().await;
-    emit_capture_event(
-        recorder,
-        CaptureEvent::DiagnosticJobCompleted {
-            job_id: job.id().to_string(),
-            status: if recoverable {
-                JobStatus::CompletedWithErrors
-            } else {
-                JobStatus::Completed
+    if let Some(cancellation) = cancellation {
+        cancellation.abort();
+    }
+    if cancelled {
+        emit_capture_event(
+            recorder,
+            CaptureEvent::diagnostic_job_cancelled(job.id().to_string()),
+        )
+        .await?;
+    } else {
+        emit_capture_event(
+            recorder,
+            CaptureEvent::DiagnosticJobCompleted {
+                job_id: job.id().to_string(),
+                status: if recoverable {
+                    JobStatus::CompletedWithErrors
+                } else {
+                    JobStatus::Completed
+                },
             },
-        },
-    )
-    .await?;
+        )
+        .await?;
+    }
     finish_diagnostic(runtime, state, recorder).await?;
     shutdown
+}
+
+fn capture_offset_us(started: Instant) -> Result<u64, String> {
+    started
+        .elapsed()
+        .as_micros()
+        .try_into()
+        .map_err(|_| "EA189 DPF capture duration exceeds supported range".into())
 }
 
 fn job_target(job: &DiagnosticJob) -> Result<KnownTarget, String> {
@@ -2018,8 +2154,19 @@ fn render_dpf_report(
     }
     output.push_str("Signals\n");
     for summary in report.summaries() {
+        let offsets = summary
+            .first_offset_us()
+            .zip(summary.last_offset_us())
+            .map(|(first, last)| {
+                format!(
+                    "; offsets: {:.3} s / {:.3} s",
+                    first as f64 / 1_000_000.0,
+                    last as f64 / 1_000_000.0,
+                )
+            })
+            .unwrap_or_default();
         output.push_str(&format!(
-            "  {}\n    samples: {}; first/last: {:.3} / {:.3} {}; delta: {:+.3}; range: {:.3} .. {:.3}\n",
+            "  {}\n    samples: {}; first/last: {:.3} / {:.3} {}; delta: {:+.3}; range: {:.3} .. {:.3}{}\n",
             summary.semantic(),
             summary.count(),
             summary.first_value(),
@@ -2028,6 +2175,7 @@ fn render_dpf_report(
             summary.delta(),
             summary.min(),
             summary.max(),
+            offsets,
         ));
     }
     if label == "across input order" {
@@ -2131,6 +2279,23 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
                 adapter_id: adapter_id.clone(),
                 profile: profile_name.clone(),
                 recording: path.clone(),
+            })
+        }
+        [command, adapter_flag, adapter_id, profile_flag, profile, record_flag, path, cycles_flag, cycles, interval_flag, interval_seconds]
+            if command == "capture"
+                && profile == "ea189-dpf"
+                && adapter_flag == "--adapter"
+                && profile_flag == "--profile"
+                && record_flag == "--record"
+                && cycles_flag == "--cycles"
+                && interval_flag == "--interval-seconds" =>
+        {
+            require_uuid(adapter_id)?;
+            Ok(Command::CaptureEa189DpfTrace {
+                adapter_id: adapter_id.clone(),
+                recording: path.clone(),
+                cycles: parse_trace_cycles(cycles)?,
+                interval: Duration::from_secs(parse_trace_interval_seconds(interval_seconds)?),
             })
         }
         [command, action, path] if command == "capture" && action == "inspect" => {
@@ -2267,6 +2432,25 @@ fn require_uuid(value: &str) -> Result<(), String> {
     valid
         .then_some(())
         .ok_or_else(|| "adapter must be a CoreBluetooth UUID".into())
+}
+
+fn parse_trace_cycles(value: &str) -> Result<u16, String> {
+    let cycles = value
+        .parse::<u16>()
+        .map_err(|_| "EA189 DPF trace cycles must be an integer from 1 to 1440".to_string())?;
+    if cycles == 0 || cycles > 1_440 {
+        return Err("EA189 DPF trace cycles must be an integer from 1 to 1440".into());
+    }
+    Ok(cycles)
+}
+
+fn parse_trace_interval_seconds(value: &str) -> Result<u64, String> {
+    let seconds = value
+        .parse::<u64>()
+        .map_err(|_| "EA189 DPF trace interval must be at least 30 seconds".to_string())?;
+    (seconds >= 30)
+        .then_some(seconds)
+        .ok_or_else(|| "EA189 DPF trace interval must be at least 30 seconds".into())
 }
 
 fn render_signals() -> String {
@@ -2555,6 +2739,27 @@ mod tests {
             })
         );
         assert_eq!(
+            parse_command(&args(&[
+                "capture",
+                "--adapter",
+                uuid,
+                "--profile",
+                "ea189-dpf",
+                "--record",
+                "trace.jsonl",
+                "--cycles",
+                "120",
+                "--interval-seconds",
+                "60",
+            ])),
+            Ok(Command::CaptureEa189DpfTrace {
+                adapter_id: uuid.into(),
+                recording: "trace.jsonl".into(),
+                cycles: 120,
+                interval: Duration::from_secs(60),
+            })
+        );
+        assert_eq!(
             parse_command(&args(&["tui", "demo"])),
             Ok(Command::TuiDemo(None))
         );
@@ -2784,6 +2989,12 @@ mod tests {
             parse_command(&args(&["vehicle", "identify", "--adapter", "UUID"])),
             Err("adapter must be a CoreBluetooth UUID".into())
         );
+        for value in ["0", "1441", "not-a-number"] {
+            assert!(parse_trace_cycles(value).is_err());
+        }
+        for value in ["0", "29", "not-a-number"] {
+            assert!(parse_trace_interval_seconds(value).is_err());
+        }
         assert_eq!(
             parse_command(&args(&["vehicle", "identify", "--adapter"])),
             Err(USAGE.into())


### PR DESCRIPTION
## Summary
- add a finite `capture --profile ea189-dpf` trace over the closed seven-DID probe
- retain one initialized BLE/ELM session across sequential cycles; never overlap vehicle commands
- record monotonic response offsets for DPF raw evidence and replay them offline
- keep legacy JSONL captures readable and document the trace workflow

## Safety and privacy
- no new DIDs, free requests, session-control commands, or writes
- cycles are bounded to 1..=1440; the pause between complete cycles is at least 30 seconds
- Ctrl-C stops after the active bounded read, then disconnects and flushes the recorder
- captures remain local and untracked

## Checks
- cargo fmt --check
- cargo test --locked
- cargo clippy --all-targets -- -D warnings
- cargo build --locked

Refs #14