### PR TITLE
Extract shared ELM dialect initialization

### DIFF
--- a/src/ble.rs
+++ b/src/ble.rs
@@ -22,6 +22,8 @@ use std::{
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{sleep, timeout};
 
+pub(crate) use crate::elm::{initialize_elm, require_response, verify_elm327, ElmExchange};
+
 const CARLY_SERVICE: u16 = 0xFFE0;
 const CARLY_CHANNEL: u16 = 0xFFE1;
 const SCAN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -1299,6 +1301,14 @@ impl DiagnosticSession {
             notifications: &mut self.notifications,
             show_adapter_io: self.show_adapter_io,
         };
+        verify_elm327(&mut exchange).await?;
+        let identity = exchange.exchange("AT@1\r", Duration::from_secs(3)).await?;
+        require_response(
+            &identity,
+            "CARLY-UNIVERSAL",
+            false,
+            "AT@1 did not identify a Carly adapter",
+        )?;
         initialize_elm(&mut exchange).await
     }
 
@@ -1392,14 +1402,6 @@ fn carly_channel(peripheral: &Peripheral) -> Result<Characteristic, String> {
     Ok(channel)
 }
 
-pub(crate) trait ElmExchange {
-    async fn exchange(
-        &mut self,
-        command: &str,
-        command_timeout: Duration,
-    ) -> Result<String, String>;
-}
-
 struct LiveExchange<'a, S> {
     peripheral: &'a Peripheral,
     channel: &'a Characteristic,
@@ -1426,40 +1428,6 @@ where
         )
         .await
     }
-}
-
-async fn initialize_elm<E>(exchange: &mut E) -> Result<(), String>
-where
-    E: ElmExchange,
-{
-    let ati = exchange.exchange("ATI\r", Duration::from_secs(3)).await?;
-    require_response(
-        &ati,
-        "ELM327",
-        false,
-        "ATI did not identify an ELM327 adapter",
-    )?;
-    let identity = exchange.exchange("AT@1\r", Duration::from_secs(3)).await?;
-    require_response(
-        &identity,
-        "CARLY-UNIVERSAL",
-        false,
-        "AT@1 did not identify a Carly adapter",
-    )?;
-    let reset = exchange.exchange("ATZ\r", Duration::from_secs(3)).await?;
-    require_response(
-        &reset,
-        "ELM327",
-        false,
-        "ATZ did not reset an ELM327 adapter",
-    )?;
-    // Keep separators and adapter headers so responder identity survives the
-    // ELM normalization boundary. No identity is synthesized when absent.
-    for command in ["ATE0\r", "ATL0\r", "ATS1\r", "ATH1\r", "ATSP0\r"] {
-        let response = exchange.exchange(command, Duration::from_secs(3)).await?;
-        require_response(&response, "OK", true, &format!("{} failed", command.trim()))?;
-    }
-    Ok(())
 }
 
 async fn discover_pid_support<E>(exchange: &mut E) -> Result<PidSupport, String>
@@ -1926,36 +1894,6 @@ fn obd_command(request: ReadRequest) -> String {
 fn uds_command(operation: crate::protocol::ReadOperation) -> String {
     let [service, high, low] = operation.request_bytes();
     format!("{service:02X}{high:02X}{low:02X}\r")
-}
-
-fn require_response(
-    response: &str,
-    expected: &str,
-    exact: bool,
-    error: &str,
-) -> Result<(), String> {
-    let upper = response.to_ascii_uppercase();
-    if upper.split(['\r', '\n']).any(|line| {
-        let line = line.trim().trim_end_matches('>').trim();
-        line == "?"
-            || ["NO DATA", "STOPPED", "UNABLE TO CONNECT", "ERROR"]
-                .iter()
-                .any(|status| line.contains(status))
-    }) {
-        return Err(format!("{error}: {response:?}"));
-    }
-    upper
-        .split(['\r', '\n'])
-        .map(|line| line.trim().trim_end_matches('>').trim())
-        .any(|line| {
-            if exact {
-                line == expected
-            } else {
-                line.starts_with(expected)
-            }
-        })
-        .then_some(())
-        .ok_or_else(|| format!("{error}: {response:?}"))
 }
 
 #[cfg(test)]
@@ -2911,8 +2849,23 @@ mod tests {
     where
         E: ElmExchange,
     {
-        initialize_elm(exchange).await?;
+        initialize_carly_elm(exchange).await?;
         discover_pid_support(exchange).await
+    }
+
+    async fn initialize_carly_elm<E>(exchange: &mut E) -> Result<(), String>
+    where
+        E: ElmExchange,
+    {
+        verify_elm327(exchange).await?;
+        let identity = exchange.exchange("AT@1\r", Duration::from_secs(3)).await?;
+        require_response(
+            &identity,
+            "CARLY-UNIVERSAL",
+            false,
+            "AT@1 did not identify a Carly adapter",
+        )?;
+        initialize_elm(exchange).await
     }
 
     fn captured_responses() -> Vec<String> {
@@ -3632,7 +3585,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn elm_initialization_does_not_probe_pid_support() {
+    async fn carly_initialization_does_not_probe_pid_support() {
         let mut exchange = ScriptedExchange::captured(vec![
             "ELM327 v1.4 v100\r>".into(),
             "carly-universal v200\r>".into(),
@@ -3644,7 +3597,7 @@ mod tests {
             "OK\r>".into(),
         ]);
 
-        initialize_elm(&mut exchange).await.unwrap();
+        initialize_carly_elm(&mut exchange).await.unwrap();
 
         assert_eq!(
             exchange.commands,

--- a/src/elm.rs
+++ b/src/elm.rs
@@ -1,0 +1,133 @@
+use std::time::Duration;
+
+/// The small protocol seam shared by ELM dialect users and transport
+/// backends.  The backend owns the actual byte exchange; this module owns
+/// only ELM command sequencing and response validation.
+pub(crate) trait ElmExchange {
+    async fn exchange(
+        &mut self,
+        command: &str,
+        command_timeout: Duration,
+    ) -> Result<String, String>;
+}
+
+/// Verify the generic ELM327 identity before any dialect-specific setup.
+pub(crate) async fn verify_elm327<E>(exchange: &mut E) -> Result<(), String>
+where
+    E: ElmExchange,
+{
+    let response = exchange.exchange("ATI\r", Duration::from_secs(3)).await?;
+    require_response(
+        &response,
+        "ELM327",
+        false,
+        "ATI did not identify an ELM327 adapter",
+    )
+}
+
+/// Complete generic ELM initialization after a backend has performed its
+/// adapter-specific identity check.  Carly calls this after `AT@1`, keeping
+/// the established wire order unchanged.
+pub(crate) async fn initialize_elm<E>(exchange: &mut E) -> Result<(), String>
+where
+    E: ElmExchange,
+{
+    let reset = exchange.exchange("ATZ\r", Duration::from_secs(3)).await?;
+    require_response(
+        &reset,
+        "ELM327",
+        false,
+        "ATZ did not reset an ELM327 adapter",
+    )?;
+    // Keep separators and adapter headers so responder identity survives the
+    // ELM normalization boundary. No identity is synthesized when absent.
+    for command in ["ATE0\r", "ATL0\r", "ATS1\r", "ATH1\r", "ATSP0\r"] {
+        let response = exchange.exchange(command, Duration::from_secs(3)).await?;
+        require_response(&response, "OK", true, &format!("{} failed", command.trim()))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn require_response(
+    response: &str,
+    expected: &str,
+    exact: bool,
+    error: &str,
+) -> Result<(), String> {
+    let upper = response.to_ascii_uppercase();
+    if upper.split(['\r', '\n']).any(|line| {
+        let line = line.trim().trim_end_matches('>').trim();
+        line == "?"
+            || ["NO DATA", "STOPPED", "UNABLE TO CONNECT", "ERROR"]
+                .iter()
+                .any(|status| line.contains(status))
+    }) {
+        return Err(format!("{error}: {response:?}"));
+    }
+    upper
+        .split(['\r', '\n'])
+        .map(|line| line.trim().trim_end_matches('>').trim())
+        .any(|line| {
+            if exact {
+                line == expected
+            } else {
+                line.starts_with(expected)
+            }
+        })
+        .then_some(())
+        .ok_or_else(|| format!("{error}: {response:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    struct ScriptedExchange {
+        responses: VecDeque<String>,
+        commands: Vec<String>,
+    }
+
+    impl ScriptedExchange {
+        fn new(responses: impl IntoIterator<Item = &'static str>) -> Self {
+            Self {
+                responses: responses.into_iter().map(str::to_owned).collect(),
+                commands: Vec::new(),
+            }
+        }
+    }
+
+    impl ElmExchange for ScriptedExchange {
+        async fn exchange(
+            &mut self,
+            command: &str,
+            _command_timeout: Duration,
+        ) -> Result<String, String> {
+            self.commands.push(command.to_owned());
+            self.responses
+                .pop_front()
+                .ok_or_else(|| "script ended before adapter response".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn generic_initialization_leaves_carly_identity_to_the_backend() {
+        let mut exchange = ScriptedExchange::new([
+            "ELM327 v1.4 v100\r>",
+            "ELM327 v1.4 v100\r>",
+            "OK\r>",
+            "OK\r>",
+            "OK\r>",
+            "OK\r>",
+            "OK\r>",
+        ]);
+
+        verify_elm327(&mut exchange).await.unwrap();
+        initialize_elm(&mut exchange).await.unwrap();
+
+        assert_eq!(
+            exchange.commands,
+            ["ATI\r", "ATZ\r", "ATE0\r", "ATL0\r", "ATS1\r", "ATH1\r", "ATSP0\r"]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod diagnostic_job;
 pub mod dpf_report;
 pub mod dtc;
 pub mod ea189;
+pub(crate) mod elm;
 pub mod evidence;
 pub mod functional_discovery;
 pub mod identity;


### PR DESCRIPTION
Refs #78

Extracts the existing ELM command seam into an internal module while retaining the current Carly BLE backend and public facade. Carly-specific AT@1 validation stays in ble; generic ELM validation/configuration is isolated. The current Carly initialization order remains covered by tests.

No second adapter, raw-command API, or vehicle/scheduler change.