### PR TITLE
Add topology provider evidence contract

### DIFF
--- a/docs/topology-providers.md
+++ b/docs/topology-providers.md
@@ -1,0 +1,114 @@
+# Topology Provider evidence contract
+
+Topology Providers are the domain seam for adding reviewed manufacturer/platform **configured or installed ECU evidence** to OBDentic without turning discovery into address scanning or a raw protocol surface.
+
+This document describes the transport-free contract introduced by issue #127, the first implementation slice of #125.
+
+## Evidence meanings remain separate
+
+A Topology Provider contributes only installation/topology evidence:
+
+```text
+Topology Provider
+  -> configured / installed controller evidence
+
+functional or targeted diagnostic response
+  -> observed / reachable evidence
+
+Vehicle Knowledge
+  -> logical ECU role / semantic applicability
+
+independently reviewed addressing evidence
+  -> request target
+```
+
+These facts are deliberately not interchangeable.
+
+A controller listed by a provider is not automatically reachable. A responder observed through functional OBD is not automatically proof that the controller is configured in a manufacturer installation list. A manufacturer logical address is not a CAN request ID or another concrete transport target unless a separately reviewed mapping establishes that relationship.
+
+## Provider result
+
+A provider result carries:
+
+- stable provider ID and version;
+- applicability scope plus provenance;
+- explicit provider status;
+- explicit provider coverage state;
+- zero or more configured/installed ECU entries;
+- evidence references;
+- an optional request-target mapping only when that mapping is supplied as separate `RequestTargetEvidence`.
+
+The provider entry type has no fields for responder observations, reachability or ECU role. That prevents installation evidence from silently acquiring stronger meaning during conversion into the shared `EcuTopology` model.
+
+## Status and coverage
+
+Provider status distinguishes:
+
+- `Completed`;
+- `Unavailable` in the current context;
+- `Blocked` by an evidence/safety gate;
+- `NotApplicable`;
+- `Failed` during provider execution.
+
+Coverage distinguishes:
+
+- `Unknown`;
+- `Partial`;
+- `Complete` for the provider's declared scope;
+- `NotApplicable`.
+
+The domain constructor rejects inconsistent combinations. In particular, blocked or unavailable providers cannot claim complete coverage and cannot return installed ECU entries. A failed provider can preserve partial entries only when coverage is explicitly partial.
+
+A `Complete` provider result is scoped to that provider's declared applicability. The merge layer does not combine several unrelated provider scopes into a guessed global “complete vehicle” claim.
+
+## Deterministic merge
+
+`merge_topology_provider_results` combines provider evidence with the existing functional/observed `EcuTopology`.
+
+The rules are intentionally conservative:
+
+1. provider results and entries are normalized into deterministic order;
+2. exact duplicate entries inside one provider result are deduplicated;
+3. independent facts from separate providers retain separate provenance;
+4. functional responders absent from a provider result remain preserved;
+5. configured provider entries do not gain responders, reachability or roles;
+6. address-looking logical identifiers are never converted into request targets;
+7. an explicit request target is retained only when it arrived as independent `RequestTargetEvidence`.
+
+No value plausibility or numeric-address resemblance participates in the merge.
+
+## Coverage reporting
+
+The merged inventory keeps structured provider records rather than returning a single misleading completeness boolean.
+
+A coarse coverage class is available for presentation:
+
+```text
+FunctionalObdOnly
+TopologyProviderEvidenceAvailable
+TopologyProviderUnavailableOrBlocked
+```
+
+The full provider records remain available so consumers can show which provider completed, was partial, was blocked, failed, or did not apply.
+
+An empty blocked/failed provider result therefore never means “the vehicle has no ECUs”. It means that the manufacturer/platform installation source did not produce authoritative inventory evidence in that run.
+
+## Current EA189 / PQ35 state
+
+The existing research in `docs/research/vw-gateway-installation-list.md` and issue #35 remains a negative safety result for the owned EA189/PQ35 context.
+
+OBDentic currently does **not** have sufficiently evidenced exact gateway request, address mapping and session semantics to execute a VW installation-list provider safely. The new domain contract can represent that provider as `Blocked` with unknown coverage, but it adds no VW gateway traffic.
+
+A future live VW provider requires new reviewed evidence that resolves the #35 gaps. It must not be implemented by blind address scanning, DID scanning, undocumented session escalation or copying third-party request sequences without provenance.
+
+## Transport boundary
+
+This slice contains no provider execution trait, adapter handle, `DiagnosticSession`, BLE/ELM/CAN/UDS call or raw request field.
+
+Future orchestration may execute a reviewed provider and then produce this domain result, but transport remains below the typed diagnostic/safety boundary. The provider result itself is evidence only.
+
+## Persistence and discovery follow-up
+
+The current `VehicleCacheSnapshot::from_topology()` primarily persists observed responder/target information and does not yet retain configured-controller provider facts.
+
+That integration is intentionally a separate follow-up slice of #125. It should extend the existing private inventory/cache and `vehicle discover` orchestration rather than creating a second topology database.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod semantic_snapshot;
 pub mod subscription_policy;
 pub mod telemetry;
 pub mod topology;
+pub mod topology_provider;
 pub mod tui;
 pub mod vehicle;
 pub mod vehicle_cache;

--- a/src/topology_provider.rs
+++ b/src/topology_provider.rs
@@ -1,7 +1,7 @@
 //! Transport-free topology-provider evidence and deterministic composition.
 //!
-//! A provider result can describe configured/installed controller evidence and
-//! coverage, but it cannot issue transport requests or infer reachability,
+//! Provider results describe configured/installed controller evidence and
+//! coverage. They cannot issue transport requests or infer reachability,
 //! logical roles, or request targets from address-looking values.
 
 use std::fmt;
@@ -30,10 +30,10 @@ impl fmt::Display for TopologyProviderError {
             Self::ZeroProviderVersion => "topology provider version must be greater than zero",
             Self::EmptyManufacturer => "topology provider manufacturer must not be empty",
             Self::EmptyPlatform => "topology provider platform must not be empty",
-            Self::EmptyEvidenceReference => "topology provider evidence reference must not be empty",
-            Self::InvalidStatusCoverage => {
-                "topology provider status and coverage are inconsistent"
+            Self::EmptyEvidenceReference => {
+                "topology provider evidence reference must not be empty"
             }
+            Self::InvalidStatusCoverage => "topology provider status and coverage are inconsistent",
             Self::NonApplicableProviderHasEntries => {
                 "a not-applicable topology provider must not contain installed ECU entries"
             }
@@ -54,18 +54,11 @@ pub struct TopologyProviderId {
 
 impl TopologyProviderId {
     pub fn new(name: impl Into<String>, version: u32) -> Result<Self, TopologyProviderError> {
-        let name = name.into();
-        let name = name.trim();
-        if name.is_empty() {
-            return Err(TopologyProviderError::EmptyProviderName);
-        }
+        let name = normalize_non_empty(name.into(), TopologyProviderError::EmptyProviderName)?;
         if version == 0 {
             return Err(TopologyProviderError::ZeroProviderVersion);
         }
-        Ok(Self {
-            name: name.to_owned(),
-            version,
-        })
+        Ok(Self { name, version })
     }
 
     pub fn name(&self) -> &str {
@@ -92,12 +85,11 @@ impl TopologyProviderScope {
     }
 
     pub fn manufacturer(manufacturer: impl Into<String>) -> Result<Self, TopologyProviderError> {
-        let manufacturer = normalize_non_empty(
-            manufacturer.into(),
-            TopologyProviderError::EmptyManufacturer,
-        )?;
         Ok(Self {
-            manufacturer: Some(manufacturer),
+            manufacturer: Some(normalize_non_empty(
+                manufacturer.into(),
+                TopologyProviderError::EmptyManufacturer,
+            )?),
             platform: None,
         })
     }
@@ -110,8 +102,7 @@ impl TopologyProviderScope {
             manufacturer.into(),
             TopologyProviderError::EmptyManufacturer,
         )?;
-        let platform =
-            normalize_non_empty(platform.into(), TopologyProviderError::EmptyPlatform)?;
+        let platform = normalize_non_empty(platform.into(), TopologyProviderError::EmptyPlatform)?;
         Ok(Self {
             manufacturer: Some(manufacturer),
             platform: Some(platform),
@@ -152,12 +143,10 @@ pub struct EvidenceReference(String);
 
 impl EvidenceReference {
     pub fn new(reference: impl Into<String>) -> Result<Self, TopologyProviderError> {
-        let reference = reference.into();
-        let reference = reference.trim();
-        if reference.is_empty() {
-            return Err(TopologyProviderError::EmptyEvidenceReference);
-        }
-        Ok(Self(reference.to_owned()))
+        Ok(Self(normalize_non_empty(
+            reference.into(),
+            TopologyProviderError::EmptyEvidenceReference,
+        )?))
     }
 
     pub fn as_str(&self) -> &str {
@@ -184,9 +173,8 @@ pub enum TopologyProviderCoverage {
 
 /// One configured/installed-controller fact produced by a topology provider.
 ///
-/// The type deliberately has no responder, reachability, or role fields.  A
-/// request target can be attached only as a separate `RequestTargetEvidence`
-/// value supplied by an independently reviewed mapping.
+/// There are deliberately no responder, reachability, or role fields. A
+/// request target can only arrive as separately sourced `RequestTargetEvidence`.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct InstalledEcuEvidence {
     context: ProtocolContext,
@@ -265,12 +253,11 @@ impl TopologyProviderResult {
         let mut entries = entries.into_iter().collect::<Vec<_>>();
         entries.sort();
         entries.dedup();
+        validate_status_coverage(status, coverage, entries.is_empty())?;
 
         let mut evidence_references = evidence_references.into_iter().collect::<Vec<_>>();
         evidence_references.sort();
         evidence_references.dedup();
-
-        validate_status_coverage(status, coverage, entries.is_empty())?;
 
         Ok(Self {
             id,
@@ -307,7 +294,11 @@ impl TopologyProviderResult {
     }
 
     pub fn to_topology(&self) -> EcuTopology {
-        EcuTopology::from_nodes(self.entries.iter().map(InstalledEcuEvidence::to_topology_node))
+        EcuTopology::from_nodes(
+            self.entries
+                .iter()
+                .map(InstalledEcuEvidence::to_topology_node),
+        )
     }
 
     fn coverage_record(&self) -> TopologyProviderCoverageRecord {
@@ -353,10 +344,8 @@ pub enum TopologyInventoryCoverageClass {
     TopologyProviderUnavailableOrBlocked,
 }
 
-/// Structured coverage state for a merged topology inventory.
-///
-/// This deliberately retains every provider record rather than collapsing
-/// multiple provider scopes into a guessed global "complete vehicle" flag.
+/// Coverage remains structured so separate provider scopes are never collapsed
+/// into a guessed global "complete vehicle" boolean.
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct TopologyInventoryCoverage {
     functional_obd_evidence_present: bool,
@@ -424,14 +413,15 @@ impl TopologyInventory {
     }
 }
 
-/// Merge configured/installed provider facts with an existing functional OBD
-/// topology.  The merge is evidence-only: it never performs I/O or infers a
-/// link between provider entries and observed responders.
-pub fn merge_topology_provider_results<'a>(
+/// Merge provider evidence with the existing functional OBD topology.
+///
+/// This performs no I/O and never infers links between provider entries and
+/// observed responders.
+pub fn merge_topology_provider_results(
     functional_topology: &EcuTopology,
-    provider_results: impl IntoIterator<Item = &'a TopologyProviderResult>,
+    provider_results: &[TopologyProviderResult],
 ) -> TopologyInventory {
-    let mut provider_results = provider_results.into_iter().collect::<Vec<_>>();
+    let mut provider_results = provider_results.to_vec();
     provider_results.sort();
     provider_results.dedup();
 
@@ -445,12 +435,11 @@ pub fn merge_topology_provider_results<'a>(
             && matches!(node.context().addressing(), AddressingContext::Functional)
             && !node.observed_responders().is_empty()
     });
-
     let coverage = TopologyInventoryCoverage::new(
         functional_obd_evidence_present,
         provider_results
             .iter()
-            .map(|result| result.coverage_record()),
+            .map(TopologyProviderResult::coverage_record),
     );
 
     TopologyInventory { topology, coverage }
@@ -462,9 +451,10 @@ fn normalize_non_empty(
 ) -> Result<String, TopologyProviderError> {
     let value = value.trim();
     if value.is_empty() {
-        return Err(error);
+        Err(error)
+    } else {
+        Ok(value.to_owned())
     }
-    Ok(value.to_owned())
 }
 
 fn validate_status_coverage(
@@ -472,49 +462,38 @@ fn validate_status_coverage(
     coverage: TopologyProviderCoverage,
     entries_empty: bool,
 ) -> Result<(), TopologyProviderError> {
-    match status {
-        TopologyProviderStatus::Completed => {
-            if matches!(
-                coverage,
-                TopologyProviderCoverage::Partial | TopologyProviderCoverage::Complete
-            ) {
-                Ok(())
-            } else {
-                Err(TopologyProviderError::InvalidStatusCoverage)
-            }
-        }
-        TopologyProviderStatus::Unavailable | TopologyProviderStatus::Blocked => {
-            if !entries_empty {
-                return Err(TopologyProviderError::BlockedOrUnavailableProviderHasEntries);
-            }
-            if coverage == TopologyProviderCoverage::Unknown {
-                Ok(())
-            } else {
-                Err(TopologyProviderError::InvalidStatusCoverage)
-            }
+    if matches!(
+        status,
+        TopologyProviderStatus::Blocked | TopologyProviderStatus::Unavailable
+    ) && !entries_empty
+    {
+        return Err(TopologyProviderError::BlockedOrUnavailableProviderHasEntries);
+    }
+    if status == TopologyProviderStatus::NotApplicable && !entries_empty {
+        return Err(TopologyProviderError::NonApplicableProviderHasEntries);
+    }
+
+    let valid = match status {
+        TopologyProviderStatus::Completed => matches!(
+            coverage,
+            TopologyProviderCoverage::Partial | TopologyProviderCoverage::Complete
+        ),
+        TopologyProviderStatus::Blocked | TopologyProviderStatus::Unavailable => {
+            coverage == TopologyProviderCoverage::Unknown
         }
         TopologyProviderStatus::NotApplicable => {
-            if !entries_empty {
-                return Err(TopologyProviderError::NonApplicableProviderHasEntries);
-            }
-            if coverage == TopologyProviderCoverage::NotApplicable {
-                Ok(())
-            } else {
-                Err(TopologyProviderError::InvalidStatusCoverage)
-            }
+            coverage == TopologyProviderCoverage::NotApplicable
         }
-        TopologyProviderStatus::Failed => {
-            let valid = if entries_empty {
-                coverage == TopologyProviderCoverage::Unknown
-            } else {
-                coverage == TopologyProviderCoverage::Partial
-            };
-            if valid {
-                Ok(())
-            } else {
-                Err(TopologyProviderError::InvalidStatusCoverage)
-            }
+        TopologyProviderStatus::Failed if entries_empty => {
+            coverage == TopologyProviderCoverage::Unknown
         }
+        TopologyProviderStatus::Failed => coverage == TopologyProviderCoverage::Partial,
+    };
+
+    if valid {
+        Ok(())
+    } else {
+        Err(TopologyProviderError::InvalidStatusCoverage)
     }
 }
 
@@ -545,22 +524,19 @@ mod tests {
         )
     }
 
-    fn installed(source: &str, id: &str, logical_address: &str) -> InstalledEcuEvidence {
+    fn installed(source: &str, id: &str, logical: &str) -> InstalledEcuEvidence {
         InstalledEcuEvidence::new(
             configured_context(),
             ConfiguredController::new(
                 Some(ConfiguredIdentity::new("synthetic-installation-list", id)),
-                Some(LogicalAddress::new(
-                    "synthetic-logical-address",
-                    logical_address,
-                )),
+                Some(LogicalAddress::new("synthetic-logical-address", logical)),
                 provenance(source),
             )
             .unwrap(),
         )
     }
 
-    fn completed_provider(
+    fn provider(
         name: &str,
         entries: impl IntoIterator<Item = InstalledEcuEvidence>,
     ) -> TopologyProviderResult {
@@ -576,24 +552,25 @@ mod tests {
     }
 
     fn functional_topology(responder: &str) -> EcuTopology {
-        EcuTopology::from_nodes([EcuNode::new(functional_context(), provenance("functional OBD"))
-            .with_observed_responder(ObservedResponder::new(
-                ResponderIdentity::address(functional_context(), responder),
-                provenance("functional OBD"),
-            ))])
+        EcuTopology::from_nodes([
+            EcuNode::new(functional_context(), provenance("functional OBD"))
+                .with_observed_responder(ObservedResponder::new(
+                    ResponderIdentity::address(functional_context(), responder),
+                    provenance("functional OBD"),
+                )),
+        ])
     }
 
     #[test]
-    fn configured_provider_entries_do_not_gain_reachability_or_role() {
-        let provider = completed_provider(
+    fn configured_entries_do_not_gain_reachability_or_role() {
+        let result = provider(
             "synthetic.installation-list",
             [
                 installed("provider", "engine", "01"),
                 installed("provider", "abs", "03"),
             ],
         );
-
-        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&provider]);
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), &[result]);
 
         assert_eq!(inventory.topology().nodes().len(), 2);
         assert!(inventory.topology().nodes().iter().all(|node| {
@@ -605,14 +582,13 @@ mod tests {
     }
 
     #[test]
-    fn functional_responder_not_in_provider_output_is_preserved() {
+    fn functional_responder_outside_provider_output_is_preserved() {
         let functional = functional_topology("7E8");
-        let provider = completed_provider(
+        let result = provider(
             "synthetic.installation-list",
             [installed("provider", "abs", "03")],
         );
-
-        let inventory = merge_topology_provider_results(&functional, [&provider]);
+        let inventory = merge_topology_provider_results(&functional, &[result]);
 
         assert_eq!(inventory.topology().nodes().len(), 2);
         assert_eq!(
@@ -628,19 +604,17 @@ mod tests {
     }
 
     #[test]
-    fn explicit_request_target_remains_separate_from_logical_address() {
-        let entry = installed("provider", "engine", "01").with_request_target(
-            RequestTargetEvidence::new(
+    fn request_target_requires_separate_explicit_evidence() {
+        let entry =
+            installed("provider", "engine", "01").with_request_target(RequestTargetEvidence::new(
                 RequestTarget::concrete(
                     ProtocolContext::new(Protocol::Uds, AddressingContext::Physical),
                     RequestAddress::new("reviewed-target-space", "target-engine"),
                 ),
                 provenance("independent target mapping"),
-            ),
-        );
-        let provider = completed_provider("synthetic.installation-list", [entry]);
-
-        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&provider]);
+            ));
+        let result = provider("synthetic.installation-list", [entry]);
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), &[result]);
         let node = &inventory.topology().nodes()[0];
 
         assert_eq!(
@@ -668,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn blocked_provider_is_explicit_and_cannot_claim_complete_coverage() {
+    fn blocked_and_failed_providers_cannot_claim_complete_inventory() {
         let blocked = TopologyProviderResult::new(
             TopologyProviderId::new("synthetic.blocked", 1).unwrap(),
             applicability("safety review"),
@@ -678,15 +652,23 @@ mod tests {
             [EvidenceReference::new("negative safety gate").unwrap()],
         )
         .unwrap();
-        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&blocked]);
+        let failed = TopologyProviderResult::new(
+            TopologyProviderId::new("synthetic.failed", 1).unwrap(),
+            applicability("runtime evidence"),
+            TopologyProviderStatus::Failed,
+            TopologyProviderCoverage::Unknown,
+            [],
+            [],
+        )
+        .unwrap();
+        let inventory =
+            merge_topology_provider_results(&EcuTopology::new(), &[blocked, failed]);
 
         assert_eq!(
             inventory.coverage().class(),
             TopologyInventoryCoverageClass::TopologyProviderUnavailableOrBlocked
         );
-        assert_eq!(inventory.coverage().providers()[0].status(), TopologyProviderStatus::Blocked);
         assert!(inventory.topology().nodes().is_empty());
-
         assert_eq!(
             TopologyProviderResult::new(
                 TopologyProviderId::new("synthetic.invalid", 1).unwrap(),
@@ -701,68 +683,36 @@ mod tests {
     }
 
     #[test]
-    fn failed_provider_never_becomes_an_empty_authoritative_inventory() {
-        let failed = TopologyProviderResult::new(
-            TopologyProviderId::new("synthetic.failed", 1).unwrap(),
-            applicability("runtime evidence"),
-            TopologyProviderStatus::Failed,
-            TopologyProviderCoverage::Unknown,
-            [],
-            [],
-        )
-        .unwrap();
-        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&failed]);
-
-        assert_eq!(
-            inventory.coverage().class(),
-            TopologyInventoryCoverageClass::TopologyProviderUnavailableOrBlocked
-        );
-        assert_eq!(inventory.coverage().providers()[0].coverage(), TopologyProviderCoverage::Unknown);
-        assert_eq!(
-            TopologyProviderResult::new(
-                TopologyProviderId::new("synthetic.failed-complete", 1).unwrap(),
-                applicability("runtime evidence"),
-                TopologyProviderStatus::Failed,
-                TopologyProviderCoverage::Complete,
-                [],
-                [],
-            ),
-            Err(TopologyProviderError::InvalidStatusCoverage)
-        );
-    }
-
-    #[test]
-    fn provider_order_does_not_change_merged_topology_or_coverage() {
-        let first = completed_provider(
+    fn provider_order_is_deterministic() {
+        let first = provider(
             "synthetic.first",
             [installed("first provider", "engine", "01")],
         );
-        let second = completed_provider(
+        let second = provider(
             "synthetic.second",
             [installed("second provider", "abs", "03")],
         );
         let functional = functional_topology("7E8");
 
-        let left = merge_topology_provider_results(&functional, [&first, &second]);
-        let right = merge_topology_provider_results(&functional, [&second, &first]);
-
+        let left = merge_topology_provider_results(
+            &functional,
+            &[first.clone(), second.clone()],
+        );
+        let right = merge_topology_provider_results(&functional, &[second, first]);
         assert_eq!(left, right);
     }
 
     #[test]
-    fn duplicate_same_provider_entries_normalize_but_cross_provider_provenance_remains() {
+    fn same_provider_duplicates_normalize_but_cross_provider_provenance_remains() {
         let duplicate = installed("provider one", "engine", "01");
-        let first = completed_provider(
-            "synthetic.first",
-            [duplicate.clone(), duplicate],
-        );
+        let first = provider("synthetic.first", [duplicate.clone(), duplicate]);
         assert_eq!(first.entries().len(), 1);
 
-        let second = completed_provider(
+        let second = provider(
             "synthetic.second",
             [installed("provider two", "engine", "01")],
         );
-        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&first, &second]);
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), &[first, second]);
 
         assert_eq!(inventory.topology().nodes().len(), 2);
         let sources = inventory
@@ -776,12 +726,12 @@ mod tests {
     }
 
     #[test]
-    fn logical_address_alone_never_becomes_request_target() {
-        let provider = completed_provider(
+    fn logical_address_never_becomes_request_target() {
+        let result = provider(
             "synthetic.installation-list",
             [installed("provider", "engine", "7E0")],
         );
-        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&provider]);
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), &[result]);
         let node = &inventory.topology().nodes()[0];
 
         assert_eq!(
@@ -796,12 +746,9 @@ mod tests {
     }
 
     #[test]
-    fn zero_providers_is_truthfully_functional_obd_only() {
+    fn zero_providers_is_functional_obd_only() {
         let functional = functional_topology("7E8");
-        let inventory = merge_topology_provider_results(
-            &functional,
-            std::iter::empty::<&TopologyProviderResult>(),
-        );
+        let inventory = merge_topology_provider_results(&functional, &[]);
 
         assert_eq!(inventory.topology(), &functional);
         assert_eq!(
@@ -813,7 +760,7 @@ mod tests {
     }
 
     #[test]
-    fn ea189_pq35_gateway_provider_can_remain_blocked_without_transport_surface() {
+    fn ea189_pq35_gateway_state_can_remain_blocked_without_transport() {
         let blocked = TopologyProviderResult::new(
             TopologyProviderId::new("vw.pq35.gateway-installation-list", 1).unwrap(),
             TopologyProviderApplicability::new(
@@ -826,8 +773,7 @@ mod tests {
             [EvidenceReference::new("issue #35 negative safety gate").unwrap()],
         )
         .unwrap();
-
-        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&blocked]);
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), &[blocked]);
 
         assert!(inventory.topology().nodes().is_empty());
         assert_eq!(

--- a/src/topology_provider.rs
+++ b/src/topology_provider.rs
@@ -1,0 +1,842 @@
+//! Transport-free topology-provider evidence and deterministic composition.
+//!
+//! A provider result can describe configured/installed controller evidence and
+//! coverage, but it cannot issue transport requests or infer reachability,
+//! logical roles, or request targets from address-looking values.
+
+use std::fmt;
+
+use crate::topology::{
+    AddressingContext, ConfiguredController, EcuNode, EcuTopology, Protocol, ProtocolContext,
+    Provenance, RequestTargetEvidence,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TopologyProviderError {
+    EmptyProviderName,
+    ZeroProviderVersion,
+    EmptyManufacturer,
+    EmptyPlatform,
+    EmptyEvidenceReference,
+    InvalidStatusCoverage,
+    NonApplicableProviderHasEntries,
+    BlockedOrUnavailableProviderHasEntries,
+}
+
+impl fmt::Display for TopologyProviderError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::EmptyProviderName => "topology provider name must not be empty",
+            Self::ZeroProviderVersion => "topology provider version must be greater than zero",
+            Self::EmptyManufacturer => "topology provider manufacturer must not be empty",
+            Self::EmptyPlatform => "topology provider platform must not be empty",
+            Self::EmptyEvidenceReference => "topology provider evidence reference must not be empty",
+            Self::InvalidStatusCoverage => {
+                "topology provider status and coverage are inconsistent"
+            }
+            Self::NonApplicableProviderHasEntries => {
+                "a not-applicable topology provider must not contain installed ECU entries"
+            }
+            Self::BlockedOrUnavailableProviderHasEntries => {
+                "a blocked or unavailable topology provider must not contain installed ECU entries"
+            }
+        })
+    }
+}
+
+impl std::error::Error for TopologyProviderError {}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct TopologyProviderId {
+    name: String,
+    version: u32,
+}
+
+impl TopologyProviderId {
+    pub fn new(name: impl Into<String>, version: u32) -> Result<Self, TopologyProviderError> {
+        let name = name.into();
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(TopologyProviderError::EmptyProviderName);
+        }
+        if version == 0 {
+            return Err(TopologyProviderError::ZeroProviderVersion);
+        }
+        Ok(Self {
+            name: name.to_owned(),
+            version,
+        })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn version(&self) -> u32 {
+        self.version
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct TopologyProviderScope {
+    manufacturer: Option<String>,
+    platform: Option<String>,
+}
+
+impl TopologyProviderScope {
+    pub fn generic() -> Self {
+        Self {
+            manufacturer: None,
+            platform: None,
+        }
+    }
+
+    pub fn manufacturer(manufacturer: impl Into<String>) -> Result<Self, TopologyProviderError> {
+        let manufacturer = normalize_non_empty(
+            manufacturer.into(),
+            TopologyProviderError::EmptyManufacturer,
+        )?;
+        Ok(Self {
+            manufacturer: Some(manufacturer),
+            platform: None,
+        })
+    }
+
+    pub fn platform(
+        manufacturer: impl Into<String>,
+        platform: impl Into<String>,
+    ) -> Result<Self, TopologyProviderError> {
+        let manufacturer = normalize_non_empty(
+            manufacturer.into(),
+            TopologyProviderError::EmptyManufacturer,
+        )?;
+        let platform =
+            normalize_non_empty(platform.into(), TopologyProviderError::EmptyPlatform)?;
+        Ok(Self {
+            manufacturer: Some(manufacturer),
+            platform: Some(platform),
+        })
+    }
+
+    pub fn manufacturer_name(&self) -> Option<&str> {
+        self.manufacturer.as_deref()
+    }
+
+    pub fn platform_name(&self) -> Option<&str> {
+        self.platform.as_deref()
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct TopologyProviderApplicability {
+    scope: TopologyProviderScope,
+    provenance: Provenance,
+}
+
+impl TopologyProviderApplicability {
+    pub fn new(scope: TopologyProviderScope, provenance: Provenance) -> Self {
+        Self { scope, provenance }
+    }
+
+    pub fn scope(&self) -> &TopologyProviderScope {
+        &self.scope
+    }
+
+    pub fn provenance(&self) -> &Provenance {
+        &self.provenance
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct EvidenceReference(String);
+
+impl EvidenceReference {
+    pub fn new(reference: impl Into<String>) -> Result<Self, TopologyProviderError> {
+        let reference = reference.into();
+        let reference = reference.trim();
+        if reference.is_empty() {
+            return Err(TopologyProviderError::EmptyEvidenceReference);
+        }
+        Ok(Self(reference.to_owned()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub enum TopologyProviderStatus {
+    Completed,
+    Unavailable,
+    Blocked,
+    NotApplicable,
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub enum TopologyProviderCoverage {
+    Unknown,
+    Partial,
+    Complete,
+    NotApplicable,
+}
+
+/// One configured/installed-controller fact produced by a topology provider.
+///
+/// The type deliberately has no responder, reachability, or role fields.  A
+/// request target can be attached only as a separate `RequestTargetEvidence`
+/// value supplied by an independently reviewed mapping.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct InstalledEcuEvidence {
+    context: ProtocolContext,
+    configured: ConfiguredController,
+    request_target: Option<RequestTargetEvidence>,
+    evidence_references: Vec<EvidenceReference>,
+}
+
+impl InstalledEcuEvidence {
+    pub fn new(context: ProtocolContext, configured: ConfiguredController) -> Self {
+        Self {
+            context,
+            configured,
+            request_target: None,
+            evidence_references: Vec::new(),
+        }
+    }
+
+    pub fn with_request_target(mut self, request_target: RequestTargetEvidence) -> Self {
+        self.request_target = Some(request_target);
+        self
+    }
+
+    pub fn with_evidence_reference(mut self, reference: EvidenceReference) -> Self {
+        self.evidence_references.push(reference);
+        self.evidence_references.sort();
+        self.evidence_references.dedup();
+        self
+    }
+
+    pub fn context(&self) -> &ProtocolContext {
+        &self.context
+    }
+
+    pub fn configured_controller(&self) -> &ConfiguredController {
+        &self.configured
+    }
+
+    pub fn request_target(&self) -> Option<&RequestTargetEvidence> {
+        self.request_target.as_ref()
+    }
+
+    pub fn evidence_references(&self) -> &[EvidenceReference] {
+        &self.evidence_references
+    }
+
+    pub fn to_topology_node(&self) -> EcuNode {
+        let mut node = EcuNode::new(self.context.clone(), self.configured.provenance().clone())
+            .with_configured_controller(self.configured.clone());
+        if let Some(request_target) = &self.request_target {
+            node = node.with_request_target(request_target.clone());
+        }
+        node
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct TopologyProviderResult {
+    id: TopologyProviderId,
+    applicability: TopologyProviderApplicability,
+    status: TopologyProviderStatus,
+    coverage: TopologyProviderCoverage,
+    entries: Vec<InstalledEcuEvidence>,
+    evidence_references: Vec<EvidenceReference>,
+}
+
+impl TopologyProviderResult {
+    pub fn new(
+        id: TopologyProviderId,
+        applicability: TopologyProviderApplicability,
+        status: TopologyProviderStatus,
+        coverage: TopologyProviderCoverage,
+        entries: impl IntoIterator<Item = InstalledEcuEvidence>,
+        evidence_references: impl IntoIterator<Item = EvidenceReference>,
+    ) -> Result<Self, TopologyProviderError> {
+        let mut entries = entries.into_iter().collect::<Vec<_>>();
+        entries.sort();
+        entries.dedup();
+
+        let mut evidence_references = evidence_references.into_iter().collect::<Vec<_>>();
+        evidence_references.sort();
+        evidence_references.dedup();
+
+        validate_status_coverage(status, coverage, entries.is_empty())?;
+
+        Ok(Self {
+            id,
+            applicability,
+            status,
+            coverage,
+            entries,
+            evidence_references,
+        })
+    }
+
+    pub fn id(&self) -> &TopologyProviderId {
+        &self.id
+    }
+
+    pub fn applicability(&self) -> &TopologyProviderApplicability {
+        &self.applicability
+    }
+
+    pub const fn status(&self) -> TopologyProviderStatus {
+        self.status
+    }
+
+    pub const fn coverage(&self) -> TopologyProviderCoverage {
+        self.coverage
+    }
+
+    pub fn entries(&self) -> &[InstalledEcuEvidence] {
+        &self.entries
+    }
+
+    pub fn evidence_references(&self) -> &[EvidenceReference] {
+        &self.evidence_references
+    }
+
+    pub fn to_topology(&self) -> EcuTopology {
+        EcuTopology::from_nodes(self.entries.iter().map(InstalledEcuEvidence::to_topology_node))
+    }
+
+    fn coverage_record(&self) -> TopologyProviderCoverageRecord {
+        TopologyProviderCoverageRecord {
+            id: self.id.clone(),
+            applicability: self.applicability.clone(),
+            status: self.status,
+            coverage: self.coverage,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct TopologyProviderCoverageRecord {
+    id: TopologyProviderId,
+    applicability: TopologyProviderApplicability,
+    status: TopologyProviderStatus,
+    coverage: TopologyProviderCoverage,
+}
+
+impl TopologyProviderCoverageRecord {
+    pub fn id(&self) -> &TopologyProviderId {
+        &self.id
+    }
+
+    pub fn applicability(&self) -> &TopologyProviderApplicability {
+        &self.applicability
+    }
+
+    pub const fn status(&self) -> TopologyProviderStatus {
+        self.status
+    }
+
+    pub const fn coverage(&self) -> TopologyProviderCoverage {
+        self.coverage
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub enum TopologyInventoryCoverageClass {
+    FunctionalObdOnly,
+    TopologyProviderEvidenceAvailable,
+    TopologyProviderUnavailableOrBlocked,
+}
+
+/// Structured coverage state for a merged topology inventory.
+///
+/// This deliberately retains every provider record rather than collapsing
+/// multiple provider scopes into a guessed global "complete vehicle" flag.
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct TopologyInventoryCoverage {
+    functional_obd_evidence_present: bool,
+    providers: Vec<TopologyProviderCoverageRecord>,
+}
+
+impl TopologyInventoryCoverage {
+    fn new(
+        functional_obd_evidence_present: bool,
+        providers: impl IntoIterator<Item = TopologyProviderCoverageRecord>,
+    ) -> Self {
+        let mut providers = providers.into_iter().collect::<Vec<_>>();
+        providers.sort();
+        providers.dedup();
+        Self {
+            functional_obd_evidence_present,
+            providers,
+        }
+    }
+
+    pub const fn functional_obd_evidence_present(&self) -> bool {
+        self.functional_obd_evidence_present
+    }
+
+    pub fn providers(&self) -> &[TopologyProviderCoverageRecord] {
+        &self.providers
+    }
+
+    pub fn class(&self) -> TopologyInventoryCoverageClass {
+        if self.providers.iter().any(|record| {
+            matches!(
+                record.coverage(),
+                TopologyProviderCoverage::Partial | TopologyProviderCoverage::Complete
+            )
+        }) {
+            TopologyInventoryCoverageClass::TopologyProviderEvidenceAvailable
+        } else if self.providers.iter().any(|record| {
+            matches!(
+                record.status(),
+                TopologyProviderStatus::Blocked
+                    | TopologyProviderStatus::Unavailable
+                    | TopologyProviderStatus::Failed
+            )
+        }) {
+            TopologyInventoryCoverageClass::TopologyProviderUnavailableOrBlocked
+        } else {
+            TopologyInventoryCoverageClass::FunctionalObdOnly
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct TopologyInventory {
+    topology: EcuTopology,
+    coverage: TopologyInventoryCoverage,
+}
+
+impl TopologyInventory {
+    pub fn topology(&self) -> &EcuTopology {
+        &self.topology
+    }
+
+    pub fn coverage(&self) -> &TopologyInventoryCoverage {
+        &self.coverage
+    }
+}
+
+/// Merge configured/installed provider facts with an existing functional OBD
+/// topology.  The merge is evidence-only: it never performs I/O or infers a
+/// link between provider entries and observed responders.
+pub fn merge_topology_provider_results<'a>(
+    functional_topology: &EcuTopology,
+    provider_results: impl IntoIterator<Item = &'a TopologyProviderResult>,
+) -> TopologyInventory {
+    let mut provider_results = provider_results.into_iter().collect::<Vec<_>>();
+    provider_results.sort();
+    provider_results.dedup();
+
+    let mut topology = functional_topology.clone();
+    for result in &provider_results {
+        topology = topology.merge(result.to_topology());
+    }
+
+    let functional_obd_evidence_present = functional_topology.nodes().iter().any(|node| {
+        matches!(node.context().protocol(), Protocol::Obd2)
+            && matches!(node.context().addressing(), AddressingContext::Functional)
+            && !node.observed_responders().is_empty()
+    });
+
+    let coverage = TopologyInventoryCoverage::new(
+        functional_obd_evidence_present,
+        provider_results
+            .iter()
+            .map(|result| result.coverage_record()),
+    );
+
+    TopologyInventory { topology, coverage }
+}
+
+fn normalize_non_empty(
+    value: String,
+    error: TopologyProviderError,
+) -> Result<String, TopologyProviderError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(error);
+    }
+    Ok(value.to_owned())
+}
+
+fn validate_status_coverage(
+    status: TopologyProviderStatus,
+    coverage: TopologyProviderCoverage,
+    entries_empty: bool,
+) -> Result<(), TopologyProviderError> {
+    match status {
+        TopologyProviderStatus::Completed => {
+            if matches!(
+                coverage,
+                TopologyProviderCoverage::Partial | TopologyProviderCoverage::Complete
+            ) {
+                Ok(())
+            } else {
+                Err(TopologyProviderError::InvalidStatusCoverage)
+            }
+        }
+        TopologyProviderStatus::Unavailable | TopologyProviderStatus::Blocked => {
+            if !entries_empty {
+                return Err(TopologyProviderError::BlockedOrUnavailableProviderHasEntries);
+            }
+            if coverage == TopologyProviderCoverage::Unknown {
+                Ok(())
+            } else {
+                Err(TopologyProviderError::InvalidStatusCoverage)
+            }
+        }
+        TopologyProviderStatus::NotApplicable => {
+            if !entries_empty {
+                return Err(TopologyProviderError::NonApplicableProviderHasEntries);
+            }
+            if coverage == TopologyProviderCoverage::NotApplicable {
+                Ok(())
+            } else {
+                Err(TopologyProviderError::InvalidStatusCoverage)
+            }
+        }
+        TopologyProviderStatus::Failed => {
+            let valid = if entries_empty {
+                coverage == TopologyProviderCoverage::Unknown
+            } else {
+                coverage == TopologyProviderCoverage::Partial
+            };
+            if valid {
+                Ok(())
+            } else {
+                Err(TopologyProviderError::InvalidStatusCoverage)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::topology::{
+        Confidence, ConfiguredIdentity, LogicalAddress, ObservedResponder, RequestAddress,
+        RequestTarget, ResponderIdentity,
+    };
+
+    fn provenance(source: &str) -> Provenance {
+        Provenance::new(source, Confidence::High).unwrap()
+    }
+
+    fn configured_context() -> ProtocolContext {
+        ProtocolContext::new(Protocol::Uds, AddressingContext::Unknown)
+    }
+
+    fn functional_context() -> ProtocolContext {
+        ProtocolContext::new(Protocol::Obd2, AddressingContext::Functional)
+    }
+
+    fn applicability(source: &str) -> TopologyProviderApplicability {
+        TopologyProviderApplicability::new(
+            TopologyProviderScope::platform("Synthetic Motors", "Test Platform").unwrap(),
+            provenance(source),
+        )
+    }
+
+    fn installed(source: &str, id: &str, logical_address: &str) -> InstalledEcuEvidence {
+        InstalledEcuEvidence::new(
+            configured_context(),
+            ConfiguredController::new(
+                Some(ConfiguredIdentity::new("synthetic-installation-list", id)),
+                Some(LogicalAddress::new(
+                    "synthetic-logical-address",
+                    logical_address,
+                )),
+                provenance(source),
+            )
+            .unwrap(),
+        )
+    }
+
+    fn completed_provider(
+        name: &str,
+        entries: impl IntoIterator<Item = InstalledEcuEvidence>,
+    ) -> TopologyProviderResult {
+        TopologyProviderResult::new(
+            TopologyProviderId::new(name, 1).unwrap(),
+            applicability("synthetic applicability"),
+            TopologyProviderStatus::Completed,
+            TopologyProviderCoverage::Partial,
+            entries,
+            [EvidenceReference::new("synthetic fixture").unwrap()],
+        )
+        .unwrap()
+    }
+
+    fn functional_topology(responder: &str) -> EcuTopology {
+        EcuTopology::from_nodes([EcuNode::new(functional_context(), provenance("functional OBD"))
+            .with_observed_responder(ObservedResponder::new(
+                ResponderIdentity::address(functional_context(), responder),
+                provenance("functional OBD"),
+            ))])
+    }
+
+    #[test]
+    fn configured_provider_entries_do_not_gain_reachability_or_role() {
+        let provider = completed_provider(
+            "synthetic.installation-list",
+            [
+                installed("provider", "engine", "01"),
+                installed("provider", "abs", "03"),
+            ],
+        );
+
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&provider]);
+
+        assert_eq!(inventory.topology().nodes().len(), 2);
+        assert!(inventory.topology().nodes().iter().all(|node| {
+            node.configured_controller().is_some()
+                && node.observed_responders().is_empty()
+                && node.reachability().is_none()
+                && node.role().is_none()
+        }));
+    }
+
+    #[test]
+    fn functional_responder_not_in_provider_output_is_preserved() {
+        let functional = functional_topology("7E8");
+        let provider = completed_provider(
+            "synthetic.installation-list",
+            [installed("provider", "abs", "03")],
+        );
+
+        let inventory = merge_topology_provider_results(&functional, [&provider]);
+
+        assert_eq!(inventory.topology().nodes().len(), 2);
+        assert_eq!(
+            inventory
+                .topology()
+                .nodes()
+                .iter()
+                .filter(|node| !node.observed_responders().is_empty())
+                .count(),
+            1
+        );
+        assert!(inventory.coverage().functional_obd_evidence_present());
+    }
+
+    #[test]
+    fn explicit_request_target_remains_separate_from_logical_address() {
+        let entry = installed("provider", "engine", "01").with_request_target(
+            RequestTargetEvidence::new(
+                RequestTarget::concrete(
+                    ProtocolContext::new(Protocol::Uds, AddressingContext::Physical),
+                    RequestAddress::new("reviewed-target-space", "target-engine"),
+                ),
+                provenance("independent target mapping"),
+            ),
+        );
+        let provider = completed_provider("synthetic.installation-list", [entry]);
+
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&provider]);
+        let node = &inventory.topology().nodes()[0];
+
+        assert_eq!(
+            node.configured_controller()
+                .unwrap()
+                .logical_address()
+                .unwrap()
+                .value(),
+            "01"
+        );
+        assert_eq!(
+            node.request_target()
+                .unwrap()
+                .target()
+                .address()
+                .unwrap()
+                .value(),
+            "target-engine"
+        );
+        assert_eq!(
+            node.request_target().unwrap().provenance().source(),
+            "independent target mapping"
+        );
+        assert!(node.observed_responders().is_empty());
+    }
+
+    #[test]
+    fn blocked_provider_is_explicit_and_cannot_claim_complete_coverage() {
+        let blocked = TopologyProviderResult::new(
+            TopologyProviderId::new("synthetic.blocked", 1).unwrap(),
+            applicability("safety review"),
+            TopologyProviderStatus::Blocked,
+            TopologyProviderCoverage::Unknown,
+            [],
+            [EvidenceReference::new("negative safety gate").unwrap()],
+        )
+        .unwrap();
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&blocked]);
+
+        assert_eq!(
+            inventory.coverage().class(),
+            TopologyInventoryCoverageClass::TopologyProviderUnavailableOrBlocked
+        );
+        assert_eq!(inventory.coverage().providers()[0].status(), TopologyProviderStatus::Blocked);
+        assert!(inventory.topology().nodes().is_empty());
+
+        assert_eq!(
+            TopologyProviderResult::new(
+                TopologyProviderId::new("synthetic.invalid", 1).unwrap(),
+                applicability("safety review"),
+                TopologyProviderStatus::Blocked,
+                TopologyProviderCoverage::Complete,
+                [],
+                [],
+            ),
+            Err(TopologyProviderError::InvalidStatusCoverage)
+        );
+    }
+
+    #[test]
+    fn failed_provider_never_becomes_an_empty_authoritative_inventory() {
+        let failed = TopologyProviderResult::new(
+            TopologyProviderId::new("synthetic.failed", 1).unwrap(),
+            applicability("runtime evidence"),
+            TopologyProviderStatus::Failed,
+            TopologyProviderCoverage::Unknown,
+            [],
+            [],
+        )
+        .unwrap();
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&failed]);
+
+        assert_eq!(
+            inventory.coverage().class(),
+            TopologyInventoryCoverageClass::TopologyProviderUnavailableOrBlocked
+        );
+        assert_eq!(inventory.coverage().providers()[0].coverage(), TopologyProviderCoverage::Unknown);
+        assert_eq!(
+            TopologyProviderResult::new(
+                TopologyProviderId::new("synthetic.failed-complete", 1).unwrap(),
+                applicability("runtime evidence"),
+                TopologyProviderStatus::Failed,
+                TopologyProviderCoverage::Complete,
+                [],
+                [],
+            ),
+            Err(TopologyProviderError::InvalidStatusCoverage)
+        );
+    }
+
+    #[test]
+    fn provider_order_does_not_change_merged_topology_or_coverage() {
+        let first = completed_provider(
+            "synthetic.first",
+            [installed("first provider", "engine", "01")],
+        );
+        let second = completed_provider(
+            "synthetic.second",
+            [installed("second provider", "abs", "03")],
+        );
+        let functional = functional_topology("7E8");
+
+        let left = merge_topology_provider_results(&functional, [&first, &second]);
+        let right = merge_topology_provider_results(&functional, [&second, &first]);
+
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn duplicate_same_provider_entries_normalize_but_cross_provider_provenance_remains() {
+        let duplicate = installed("provider one", "engine", "01");
+        let first = completed_provider(
+            "synthetic.first",
+            [duplicate.clone(), duplicate],
+        );
+        assert_eq!(first.entries().len(), 1);
+
+        let second = completed_provider(
+            "synthetic.second",
+            [installed("provider two", "engine", "01")],
+        );
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&first, &second]);
+
+        assert_eq!(inventory.topology().nodes().len(), 2);
+        let sources = inventory
+            .topology()
+            .nodes()
+            .iter()
+            .map(|node| node.configured_controller().unwrap().provenance().source())
+            .collect::<Vec<_>>();
+        assert!(sources.contains(&"provider one"));
+        assert!(sources.contains(&"provider two"));
+    }
+
+    #[test]
+    fn logical_address_alone_never_becomes_request_target() {
+        let provider = completed_provider(
+            "synthetic.installation-list",
+            [installed("provider", "engine", "7E0")],
+        );
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&provider]);
+        let node = &inventory.topology().nodes()[0];
+
+        assert_eq!(
+            node.configured_controller()
+                .unwrap()
+                .logical_address()
+                .unwrap()
+                .value(),
+            "7E0"
+        );
+        assert!(node.request_target().is_none());
+    }
+
+    #[test]
+    fn zero_providers_is_truthfully_functional_obd_only() {
+        let functional = functional_topology("7E8");
+        let inventory = merge_topology_provider_results(
+            &functional,
+            std::iter::empty::<&TopologyProviderResult>(),
+        );
+
+        assert_eq!(inventory.topology(), &functional);
+        assert_eq!(
+            inventory.coverage().class(),
+            TopologyInventoryCoverageClass::FunctionalObdOnly
+        );
+        assert!(inventory.coverage().functional_obd_evidence_present());
+        assert!(inventory.coverage().providers().is_empty());
+    }
+
+    #[test]
+    fn ea189_pq35_gateway_provider_can_remain_blocked_without_transport_surface() {
+        let blocked = TopologyProviderResult::new(
+            TopologyProviderId::new("vw.pq35.gateway-installation-list", 1).unwrap(),
+            TopologyProviderApplicability::new(
+                TopologyProviderScope::platform("Volkswagen", "PQ35 / EA189").unwrap(),
+                provenance("docs/research/vw-gateway-installation-list.md"),
+            ),
+            TopologyProviderStatus::Blocked,
+            TopologyProviderCoverage::Unknown,
+            [],
+            [EvidenceReference::new("issue #35 negative safety gate").unwrap()],
+        )
+        .unwrap();
+
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), [&blocked]);
+
+        assert!(inventory.topology().nodes().is_empty());
+        assert_eq!(
+            inventory.coverage().class(),
+            TopologyInventoryCoverageClass::TopologyProviderUnavailableOrBlocked
+        );
+        assert_eq!(
+            inventory.coverage().providers()[0].id().name(),
+            "vw.pq35.gateway-installation-list"
+        );
+    }
+}

--- a/src/topology_provider.rs
+++ b/src/topology_provider.rs
@@ -661,8 +661,7 @@ mod tests {
             [],
         )
         .unwrap();
-        let inventory =
-            merge_topology_provider_results(&EcuTopology::new(), &[blocked, failed]);
+        let inventory = merge_topology_provider_results(&EcuTopology::new(), &[blocked, failed]);
 
         assert_eq!(
             inventory.coverage().class(),
@@ -694,10 +693,7 @@ mod tests {
         );
         let functional = functional_topology("7E8");
 
-        let left = merge_topology_provider_results(
-            &functional,
-            &[first.clone(), second.clone()],
-        );
+        let left = merge_topology_provider_results(&functional, &[first.clone(), second.clone()]);
         let right = merge_topology_provider_results(&functional, &[second, first]);
         assert_eq!(left, right);
     }


### PR DESCRIPTION
## Summary

Implements the transport-free first slice of #125, tracked as #127.

Adds a typed Topology Provider evidence/result contract and deterministic composition with the existing `EcuTopology` model. This establishes how future reviewed manufacturer/platform installation-list sources can contribute `configured/installed` evidence without conflating it with responder reachability, ECU role, or request addressing.

## Architecture

The new seam preserves the project direction:

```text
reviewed topology source
  -> TopologyProviderResult
  -> configured/installed evidence
  -> shared EcuTopology

functional/targeted response evidence
  -> observed/reachable evidence

Vehicle Knowledge
  -> role / semantic interpretation
```

Provider entries deliberately have no responder, reachability, or role fields. A request target can only be attached as separate `RequestTargetEvidence`; a logical address is never converted automatically.

## Coverage / status

Provider results preserve:

- stable provider ID + version
- applicability scope + provenance
- status: completed / unavailable / blocked / not applicable / failed
- coverage: unknown / partial / complete / not applicable
- configured ECU entries
- evidence references

Invalid status/coverage combinations fail closed. Blocked/unavailable providers cannot return installed entries or claim complete coverage. A failed provider may retain entries only as explicit partial evidence.

The merged inventory keeps all provider coverage records rather than guessing one global complete/incomplete boolean.

## Deterministic merge

- exact duplicate entries inside one provider result are normalized
- provider/result order does not affect output
- independent provider facts retain separate provenance
- functional responders not represented by provider output remain preserved
- configured entries do not gain reachability or roles
- logical address resemblance never creates a request target

## EA189 / VW safety state

The current negative research result from #35 remains authoritative. The domain model can represent `vw.pq35.gateway-installation-list` as blocked with unknown coverage, but this PR sends **zero** VW gateway traffic and introduces no provider execution transport surface.

## Tests

Focused unit coverage includes:

- configured-only ECUs remain not reachable/role-less
- functional responder preservation
- explicit request-target evidence separation
- blocked/failed coverage semantics
- deterministic provider ordering
- same-provider deduplication vs cross-provider provenance preservation
- logical address never becoming a request target
- functional-only fallback with zero providers
- synthetic blocked EA189/PQ35 provider state

## Documentation

Adds `docs/topology-providers.md` covering evidence meanings, provider status/coverage, deterministic merge rules, transport boundary, and the current negative EA189/PQ35 gateway state.

## Explicit non-goals

- no BLE/ELM/CAN/UDS traffic
- no VW gateway request
- no discovery orchestration changes
- no `VehicleCache` schema/persistence changes
- no role inference
- no logical-address -> request-target conversion
- no scanning/session/security/write/DTC-clear path

## Main / parallel work

Based directly on current `main` `7a5761ab9ad2884c06fee8399e69af4b3cce1f06` after #124. The diff is isolated from open PRs #65, #102 and #105.

Closes #127
Advances #125