### PR TITLE
Persist topology provider evidence in vehicle cache

### DIFF
--- a/docs/topology-providers.md
+++ b/docs/topology-providers.md
@@ -2,7 +2,7 @@
 
 Topology Providers are the domain seam for adding reviewed manufacturer/platform **configured or installed ECU evidence** to OBDentic without turning discovery into address scanning or a raw protocol surface.
 
-This document describes the transport-free contract introduced by issue #127, the first implementation slice of #125.
+This document describes the transport-free contract introduced by issue #127 and its private vehicle-cache persistence added by issue #130, both implementation slices of #125.
 
 ## Evidence meanings remain separate
 
@@ -93,22 +93,62 @@ The full provider records remain available so consumers can show which provider 
 
 An empty blocked/failed provider result therefore never means “the vehicle has no ECUs”. It means that the manufacturer/platform installation source did not produce authoritative inventory evidence in that run.
 
+## Private vehicle-cache persistence
+
+Topology-provider output is **vehicle-instance evidence**, not canonical Vehicle Knowledge. It is persisted in the same local private `VehicleCacheSnapshot` that already stores observed topology, capabilities, request-target mappings and bounded ECU-identification observations.
+
+Vehicle-cache schema v5 stores complete typed `TopologyProviderResult` values, including:
+
+- provider ID/version;
+- applicability scope and provenance;
+- provider status and coverage;
+- provider-level evidence references;
+- configured-controller identity/logical-address evidence and provenance;
+- entry-level evidence references;
+- optional `RequestTargetEvidence` only when it was already supplied independently.
+
+The cache normalizes provider-result ordering deterministically. Persisting a configured controller does **not** create a responder observation, a reachability fact or an ECU role. A logical address remains a logical address after reload; the decoder never promotes it into a request target.
+
+### Cache compatibility
+
+New cache writes use:
+
+```text
+OBDENTIC-VEHICLE-CACHE  5
+```
+
+The parser continues to read v1, v2, v3 and v4. Older cache records deserialize with an empty topology-provider result collection. They are not reinterpreted as having complete or absent manufacturer topology evidence.
+
+Provider status/coverage is reconstructed through the same domain constructor used by live/in-memory results, so inconsistent combinations fail closed while loading.
+
+### Privacy and validation
+
+Provider metadata passes through the existing private-cache validation rules. Raw VIN-like identifiers are rejected from provider IDs, applicability fields, provenance, evidence references, configured identifiers/logical addresses and request-target metadata.
+
+Provider entry/reference counts are bounded during parsing. Cache files remain local vehicle evidence and must not be committed to the repository.
+
+### Validation signature remains observation-based
+
+Topology-provider installation evidence is deliberately excluded from `VehicleCacheSnapshot::validation_signature()`.
+
+That signature remains based on the bounded functional OBD evidence already used for cache revalidation. A persisted manufacturer installation list therefore cannot silently become proof that an ECU is currently reachable or that a cached request target is live-valid.
+
 ## Current EA189 / PQ35 state
 
 The existing research in `docs/research/vw-gateway-installation-list.md` and issue #35 remains a negative safety result for the owned EA189/PQ35 context.
 
-OBDentic currently does **not** have sufficiently evidenced exact gateway request, address mapping and session semantics to execute a VW installation-list provider safely. The new domain contract can represent that provider as `Blocked` with unknown coverage, but it adds no VW gateway traffic.
+OBDentic currently does **not** have sufficiently evidenced exact gateway request, address mapping and session semantics to execute a VW installation-list provider safely. The domain/cache model can represent that provider as `Blocked` with unknown coverage and persist that fact across restarts, but it adds no VW gateway traffic.
 
 A future live VW provider requires new reviewed evidence that resolves the #35 gaps. It must not be implemented by blind address scanning, DID scanning, undocumented session escalation or copying third-party request sequences without provenance.
 
 ## Transport boundary
 
-This slice contains no provider execution trait, adapter handle, `DiagnosticSession`, BLE/ELM/CAN/UDS call or raw request field.
+The provider domain and cache persistence contain no provider execution trait, adapter handle, `DiagnosticSession`, BLE/ELM/CAN/UDS call or raw request field.
 
-Future orchestration may execute a reviewed provider and then produce this domain result, but transport remains below the typed diagnostic/safety boundary. The provider result itself is evidence only.
+Future orchestration may execute a reviewed provider and then persist the resulting domain evidence, but transport remains below the typed diagnostic/safety boundary. The provider result itself is evidence only.
 
-## Persistence and discovery follow-up
+## Discovery follow-up
 
-The current `VehicleCacheSnapshot::from_topology()` primarily persists observed responder/target information and does not yet retain configured-controller provider facts.
+With the provider domain and persistence seam established, the remaining #125 integration is discovery orchestration: applicable reviewed providers can later be composed with functional OBD discovery while preserving fallback and structured partial-coverage reporting.
 
-That integration is intentionally a separate follow-up slice of #125. It should extend the existing private inventory/cache and `vehicle discover` orchestration rather than creating a second topology database.
+That orchestration remains a separate slice. It must reuse the existing private cache and topology types, and it must not add live VW/PQ35 gateway traffic until new reviewed evidence resolves issue #35.

--- a/src/vehicle_cache.rs
+++ b/src/vehicle_cache.rs
@@ -13,21 +13,30 @@ use crate::{
     },
     functional_discovery::EcuCapability,
     topology::{
-        AddressingContext, Confidence, EcuRole, EcuTopology, ObservationWindow, Protocol,
-        ProtocolContext, Provenance, RequestAddress, RequestTarget, RequestTargetEvidence,
-        ResponderIdentity, RoleAssignment,
+        AddressingContext, Confidence, ConfiguredController, ConfiguredIdentity, EcuRole,
+        EcuTopology, LogicalAddress, ObservationWindow, Protocol, ProtocolContext, Provenance,
+        RequestAddress, RequestTarget, RequestTargetEvidence, ResponderIdentity, RoleAssignment,
+    },
+    topology_provider::{
+        EvidenceReference, InstalledEcuEvidence, TopologyProviderApplicability,
+        TopologyProviderCoverage, TopologyProviderId, TopologyProviderResult, TopologyProviderScope,
+        TopologyProviderStatus,
     },
 };
 
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 
-const HEADER: &str = "OBDENTIC-VEHICLE-CACHE\t4";
+const HEADER: &str = "OBDENTIC-VEHICLE-CACHE\t5";
+const V4_HEADER: &str = "OBDENTIC-VEHICLE-CACHE\t4";
 const V3_HEADER: &str = "OBDENTIC-VEHICLE-CACHE\t3";
 const V2_HEADER: &str = "OBDENTIC-VEHICLE-CACHE\t2";
 const LEGACY_HEADER: &str = "OBDENTIC-VEHICLE-CACHE\t1";
 const INDEX_HEADER: &str = "OBDENTIC-VEHICLE-INDEX\t1";
 const INDEX_NAME: &str = ".identity-index";
+const MAX_PROVIDER_EVIDENCE_REFERENCES: usize = 256;
+const MAX_PROVIDER_ENTRIES: usize = 1024;
+const MAX_PROVIDER_ENTRY_EVIDENCE_REFERENCES: usize = 256;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VehicleCache {
@@ -114,6 +123,7 @@ pub struct VehicleCacheSnapshot {
     ecu_capabilities: Vec<EcuCapabilitySnapshot>,
     target_mappings: Vec<TargetMappingSnapshot>,
     ecu_identification: Vec<IdentificationObservation>,
+    topology_provider_results: Vec<TopologyProviderResult>,
 }
 
 impl VehicleCacheSnapshot {
@@ -136,12 +146,23 @@ impl VehicleCacheSnapshot {
             ecu_capabilities: ecu_capabilities.into_iter().collect(),
             target_mappings: target_mappings.into_iter().collect(),
             ecu_identification: ecu_identification.into_iter().collect(),
+            topology_provider_results: Vec::new(),
         };
         snapshot.topology.sort();
         snapshot.ecu_capabilities.sort();
         snapshot.target_mappings.sort();
         snapshot.ecu_identification.sort();
         snapshot
+    }
+
+    pub fn with_topology_provider_results(
+        mut self,
+        results: impl IntoIterator<Item = TopologyProviderResult>,
+    ) -> Self {
+        self.topology_provider_results = results.into_iter().collect();
+        self.topology_provider_results.sort();
+        self.topology_provider_results.dedup();
+        self
     }
 
     pub fn from_topology(topology: &EcuTopology) -> Self {
@@ -208,6 +229,10 @@ impl VehicleCacheSnapshot {
 
     pub fn ecu_identification(&self) -> &[IdentificationObservation] {
         &self.ecu_identification
+    }
+
+    pub fn topology_provider_results(&self) -> &[TopologyProviderResult] {
+        &self.topology_provider_results
     }
 
     pub fn validation_signature(&self) -> ValidationSignature {
@@ -529,6 +554,10 @@ impl CacheStore {
             for observation in &cache.snapshot.ecu_identification {
                 file.write_all(b"\necu_identification\t")?;
                 file.write_all(encode_identification_observation(observation).as_bytes())?;
+            }
+            for result in &cache.snapshot.topology_provider_results {
+                file.write_all(b"\ntopology_provider\t")?;
+                file.write_all(encode_topology_provider_result(result).as_bytes())?;
             }
             for line in &cache.history {
                 file.write_all(b"\nhistory\t")?;
@@ -861,6 +890,88 @@ fn encode_identification_observation(observation: &IdentificationObservation) ->
     encode_fields(&fields)
 }
 
+fn encode_topology_provider_result(result: &TopologyProviderResult) -> String {
+    let mut fields = vec![result.id().name().into(), result.id().version().to_string()];
+    fields.extend(encode_topology_provider_scope(
+        result.applicability().scope(),
+    ));
+    fields.extend(encode_provenance(result.applicability().provenance()));
+    fields.push(encode_topology_provider_status(result.status()).into());
+    fields.push(encode_topology_provider_coverage(result.coverage()).into());
+    fields.push(result.evidence_references().len().to_string());
+    fields.extend(
+        result
+            .evidence_references()
+            .iter()
+            .map(|reference| reference.as_str().into()),
+    );
+    fields.push(result.entries().len().to_string());
+    for entry in result.entries() {
+        fields.extend(encode_installed_ecu_evidence(entry));
+    }
+    encode_fields(&fields)
+}
+
+fn encode_topology_provider_scope(scope: &TopologyProviderScope) -> Vec<String> {
+    let mut fields = vec![
+        if scope.manufacturer_name().is_some() {
+            "1"
+        } else {
+            "0"
+        }
+        .into(),
+    ];
+    if let Some(manufacturer) = scope.manufacturer_name() {
+        fields.push(manufacturer.into());
+    }
+    fields.push(
+        if scope.platform_name().is_some() {
+            "1"
+        } else {
+            "0"
+        }
+        .into(),
+    );
+    if let Some(platform) = scope.platform_name() {
+        fields.push(platform.into());
+    }
+    fields
+}
+
+fn encode_installed_ecu_evidence(entry: &InstalledEcuEvidence) -> Vec<String> {
+    let mut fields = encode_context(entry.context()).to_vec();
+    let configured = entry.configured_controller();
+    fields.push(if configured.identity().is_some() { "1" } else { "0" }.into());
+    if let Some(identity) = configured.identity() {
+        fields.extend([identity.authority().into(), identity.identifier().into()]);
+    }
+    fields.push(
+        if configured.logical_address().is_some() {
+            "1"
+        } else {
+            "0"
+        }
+        .into(),
+    );
+    if let Some(logical) = configured.logical_address() {
+        fields.extend([logical.authority().into(), logical.value().into()]);
+    }
+    fields.extend(encode_provenance(configured.provenance()));
+    fields.push(if entry.request_target().is_some() { "1" } else { "0" }.into());
+    if let Some(target) = entry.request_target() {
+        fields.extend(encode_target(target.target()));
+        fields.extend(encode_provenance(target.provenance()));
+    }
+    fields.push(entry.evidence_references().len().to_string());
+    fields.extend(
+        entry
+            .evidence_references()
+            .iter()
+            .map(|reference| reference.as_str().into()),
+    );
+    fields
+}
+
 fn encode_identification_status(status: IdentificationResultStatus) -> &'static str {
     match status {
         IdentificationResultStatus::Supported => "supported",
@@ -871,6 +982,25 @@ fn encode_identification_status(status: IdentificationResultStatus) -> &'static 
         IdentificationResultStatus::Timeout => "timeout",
         IdentificationResultStatus::TransportError => "transport_error",
         IdentificationResultStatus::NotProbed => "not_probed",
+    }
+}
+
+fn encode_topology_provider_status(status: TopologyProviderStatus) -> &'static str {
+    match status {
+        TopologyProviderStatus::Completed => "completed",
+        TopologyProviderStatus::Unavailable => "unavailable",
+        TopologyProviderStatus::Blocked => "blocked",
+        TopologyProviderStatus::NotApplicable => "not_applicable",
+        TopologyProviderStatus::Failed => "failed",
+    }
+}
+
+fn encode_topology_provider_coverage(coverage: TopologyProviderCoverage) -> &'static str {
+    match coverage {
+        TopologyProviderCoverage::Unknown => "unknown",
+        TopologyProviderCoverage::Partial => "partial",
+        TopologyProviderCoverage::Complete => "complete",
+        TopologyProviderCoverage::NotApplicable => "not_applicable",
     }
 }
 
@@ -1085,6 +1215,21 @@ fn parse_optional_flag(fields: &[String], index: &mut usize, name: &str) -> Resu
     }
 }
 
+fn parse_count(
+    fields: &[String],
+    index: &mut usize,
+    name: &str,
+    maximum: usize,
+) -> Result<usize, String> {
+    let count = field(fields, index, name)?
+        .parse::<usize>()
+        .map_err(|error| format!("invalid {name}: {error}"))?;
+    if count > maximum {
+        return Err(format!("vehicle cache {name} exceeds {maximum}"));
+    }
+    Ok(count)
+}
+
 fn parse_target(fields: &[String], index: &mut usize) -> Result<RequestTarget, String> {
     let context = parse_context(fields, index)?;
     let has_address = parse_optional_flag(fields, index, "target address")?;
@@ -1105,7 +1250,8 @@ fn parse_target(fields: &[String], index: &mut usize) -> Result<RequestTarget, S
 fn parse(contents: &str, requested_key: &str) -> Result<VehicleCache, String> {
     let mut lines = contents.lines();
     match lines.next() {
-        Some(HEADER) => parse_v4(lines, requested_key),
+        Some(HEADER) => parse_v5(lines, requested_key),
+        Some(V4_HEADER) => parse_v4(lines, requested_key),
         Some(V3_HEADER) => parse_v3(lines, requested_key),
         Some(V2_HEADER) => parse_v2(lines, requested_key),
         Some(LEGACY_HEADER) => parse_v1(lines, requested_key),
@@ -1161,21 +1307,28 @@ fn parse_v2<'a>(
     lines: impl Iterator<Item = &'a str>,
     requested_key: &str,
 ) -> Result<VehicleCache, String> {
-    parse_versioned(lines, requested_key, false, false)
+    parse_versioned(lines, requested_key, false, false, false)
 }
 
 fn parse_v3<'a>(
     lines: impl Iterator<Item = &'a str>,
     requested_key: &str,
 ) -> Result<VehicleCache, String> {
-    parse_versioned(lines, requested_key, true, false)
+    parse_versioned(lines, requested_key, true, false, false)
 }
 
 fn parse_v4<'a>(
     lines: impl Iterator<Item = &'a str>,
     requested_key: &str,
 ) -> Result<VehicleCache, String> {
-    parse_versioned(lines, requested_key, true, true)
+    parse_versioned(lines, requested_key, true, true, false)
+}
+
+fn parse_v5<'a>(
+    lines: impl Iterator<Item = &'a str>,
+    requested_key: &str,
+) -> Result<VehicleCache, String> {
+    parse_versioned(lines, requested_key, true, true, true)
 }
 
 fn parse_versioned<'a>(
@@ -1183,6 +1336,7 @@ fn parse_versioned<'a>(
     requested_key: &str,
     has_role: bool,
     has_identification: bool,
+    has_topology_providers: bool,
 ) -> Result<VehicleCache, String> {
     let mut local_key = None;
     let mut first_seen_ms = None;
@@ -1191,6 +1345,7 @@ fn parse_versioned<'a>(
     let mut capabilities = BTreeMap::new();
     let mut target_mappings = Vec::new();
     let mut ecu_identification = Vec::new();
+    let mut topology_provider_results = Vec::new();
     let mut history = Vec::new();
     for line in lines {
         let (tag, fields) = parse_fields(line)?;
@@ -1253,6 +1408,9 @@ fn parse_versioned<'a>(
             "ecu_identification" if has_identification => {
                 ecu_identification.push(parse_identification_observation(&fields)?);
             }
+            "topology_provider" if has_topology_providers => {
+                topology_provider_results.push(parse_topology_provider_result(&fields)?);
+            }
             "history" => history.push(one_field(&fields, "history")?.to_owned()),
             "evidence" => history.push(one_field(&fields, "evidence")?.to_owned()),
             _ => return Err(format!("vehicle cache contains unsupported field {tag}")),
@@ -1265,16 +1423,18 @@ fn parse_versioned<'a>(
         last_seen_ms.ok_or_else(|| "vehicle cache is missing last_seen_ms".to_string())?,
         history,
     );
+    let snapshot = VehicleCacheSnapshot::with_ecu_identification(
+        topology,
+        capabilities.into_values(),
+        target_mappings,
+        ecu_identification,
+    )
+    .with_topology_provider_results(topology_provider_results);
     let cache = VehicleCache::with_snapshot(
         cache.local_key,
         cache.first_seen_ms,
         cache.last_seen_ms,
-        VehicleCacheSnapshot::with_ecu_identification(
-            topology,
-            capabilities.into_values(),
-            target_mappings,
-            ecu_identification,
-        ),
+        snapshot,
         cache.history,
     );
     finish_cache(cache, requested_key)
@@ -1379,6 +1539,136 @@ fn parse_target_mapping_with_role(
     ))
 }
 
+fn parse_topology_provider_result(fields: &[String]) -> Result<TopologyProviderResult, String> {
+    let mut index = 0;
+    let id = TopologyProviderId::new(
+        field(fields, &mut index, "topology provider id")?,
+        field(fields, &mut index, "topology provider version")?
+            .parse::<u32>()
+            .map_err(|error| format!("invalid topology provider version: {error}"))?,
+    )
+    .map_err(|error| error.to_string())?;
+    let scope = parse_topology_provider_scope(fields, &mut index)?;
+    let applicability = TopologyProviderApplicability::new(scope, parse_provenance(fields, &mut index)?);
+    let status = parse_topology_provider_status(field(
+        fields,
+        &mut index,
+        "topology provider status",
+    )?)?;
+    let coverage = parse_topology_provider_coverage(field(
+        fields,
+        &mut index,
+        "topology provider coverage",
+    )?)?;
+    let reference_count = parse_count(
+        fields,
+        &mut index,
+        "topology provider evidence reference count",
+        MAX_PROVIDER_EVIDENCE_REFERENCES,
+    )?;
+    let mut references = Vec::with_capacity(reference_count);
+    for _ in 0..reference_count {
+        references.push(
+            EvidenceReference::new(field(
+                fields,
+                &mut index,
+                "topology provider evidence reference",
+            )?)
+            .map_err(|error| error.to_string())?,
+        );
+    }
+    let entry_count = parse_count(
+        fields,
+        &mut index,
+        "topology provider entry count",
+        MAX_PROVIDER_ENTRIES,
+    )?;
+    let mut entries = Vec::with_capacity(entry_count);
+    for _ in 0..entry_count {
+        entries.push(parse_installed_ecu_evidence(fields, &mut index)?);
+    }
+    finish_fields(fields, index)?;
+    TopologyProviderResult::new(id, applicability, status, coverage, entries, references)
+        .map_err(|error| error.to_string())
+}
+
+fn parse_topology_provider_scope(
+    fields: &[String],
+    index: &mut usize,
+) -> Result<TopologyProviderScope, String> {
+    let manufacturer = if parse_optional_flag(fields, index, "topology provider manufacturer")? {
+        Some(field(fields, index, "topology provider manufacturer value")?.to_owned())
+    } else {
+        None
+    };
+    let platform = if parse_optional_flag(fields, index, "topology provider platform")? {
+        Some(field(fields, index, "topology provider platform value")?.to_owned())
+    } else {
+        None
+    };
+    match (manufacturer, platform) {
+        (None, None) => Ok(TopologyProviderScope::generic()),
+        (Some(manufacturer), None) => TopologyProviderScope::manufacturer(manufacturer)
+            .map_err(|error| error.to_string()),
+        (Some(manufacturer), Some(platform)) => TopologyProviderScope::platform(manufacturer, platform)
+            .map_err(|error| error.to_string()),
+        (None, Some(_)) => Err("vehicle cache topology provider platform has no manufacturer".into()),
+    }
+}
+
+fn parse_installed_ecu_evidence(
+    fields: &[String],
+    index: &mut usize,
+) -> Result<InstalledEcuEvidence, String> {
+    let context = parse_context(fields, index)?;
+    let identity = if parse_optional_flag(fields, index, "configured identity")? {
+        Some(ConfiguredIdentity::new(
+            field(fields, index, "configured identity authority")?,
+            field(fields, index, "configured identity value")?,
+        ))
+    } else {
+        None
+    };
+    let logical_address = if parse_optional_flag(fields, index, "logical address")? {
+        Some(LogicalAddress::new(
+            field(fields, index, "logical address authority")?,
+            field(fields, index, "logical address value")?,
+        ))
+    } else {
+        None
+    };
+    let configured = ConfiguredController::new(
+        identity,
+        logical_address,
+        parse_provenance(fields, index)?,
+    )
+    .map_err(|error| error.to_string())?;
+    let mut entry = InstalledEcuEvidence::new(context, configured);
+    if parse_optional_flag(fields, index, "configured request target")? {
+        entry = entry.with_request_target(RequestTargetEvidence::new(
+            parse_target(fields, index)?,
+            parse_provenance(fields, index)?,
+        ));
+    }
+    let reference_count = parse_count(
+        fields,
+        index,
+        "configured entry evidence reference count",
+        MAX_PROVIDER_ENTRY_EVIDENCE_REFERENCES,
+    )?;
+    for _ in 0..reference_count {
+        entry = entry.with_evidence_reference(
+            EvidenceReference::new(field(
+                fields,
+                index,
+                "configured entry evidence reference",
+            )?)
+            .map_err(|error| error.to_string())?,
+        );
+    }
+    Ok(entry)
+}
+
 fn parse_identification_observation(
     fields: &[String],
 ) -> Result<IdentificationObservation, String> {
@@ -1470,6 +1760,27 @@ fn parse_identification_status(value: &str) -> Result<IdentificationResultStatus
         "transport_error" => Ok(IdentificationResultStatus::TransportError),
         "not_probed" => Ok(IdentificationResultStatus::NotProbed),
         _ => Err("vehicle cache contains an invalid ECU identification status".into()),
+    }
+}
+
+fn parse_topology_provider_status(value: &str) -> Result<TopologyProviderStatus, String> {
+    match value {
+        "completed" => Ok(TopologyProviderStatus::Completed),
+        "unavailable" => Ok(TopologyProviderStatus::Unavailable),
+        "blocked" => Ok(TopologyProviderStatus::Blocked),
+        "not_applicable" => Ok(TopologyProviderStatus::NotApplicable),
+        "failed" => Ok(TopologyProviderStatus::Failed),
+        _ => Err("vehicle cache contains an invalid topology provider status".into()),
+    }
+}
+
+fn parse_topology_provider_coverage(value: &str) -> Result<TopologyProviderCoverage, String> {
+    match value {
+        "unknown" => Ok(TopologyProviderCoverage::Unknown),
+        "partial" => Ok(TopologyProviderCoverage::Partial),
+        "complete" => Ok(TopologyProviderCoverage::Complete),
+        "not_applicable" => Ok(TopologyProviderCoverage::NotApplicable),
+        _ => Err("vehicle cache contains an invalid topology provider coverage".into()),
     }
 }
 
@@ -1567,6 +1878,48 @@ fn validate_snapshot(snapshot: &VehicleCacheSnapshot) -> Result<(), String> {
             validate_text("target value", address.value())?;
         }
         validate_provenance(mapping.provenance())?;
+    }
+    for result in &snapshot.topology_provider_results {
+        validate_topology_provider_result(result)?;
+    }
+    Ok(())
+}
+
+fn validate_topology_provider_result(result: &TopologyProviderResult) -> Result<(), String> {
+    validate_text("topology provider id", result.id().name())?;
+    if let Some(manufacturer) = result.applicability().scope().manufacturer_name() {
+        validate_text("topology provider manufacturer", manufacturer)?;
+    }
+    if let Some(platform) = result.applicability().scope().platform_name() {
+        validate_text("topology provider platform", platform)?;
+    }
+    validate_provenance(result.applicability().provenance())?;
+    for reference in result.evidence_references() {
+        validate_text("topology provider evidence reference", reference.as_str())?;
+    }
+    for entry in result.entries() {
+        validate_context(entry.context())?;
+        let configured = entry.configured_controller();
+        if let Some(identity) = configured.identity() {
+            validate_text("configured identity authority", identity.authority())?;
+            validate_text("configured identity", identity.identifier())?;
+        }
+        if let Some(logical) = configured.logical_address() {
+            validate_text("logical address authority", logical.authority())?;
+            validate_text("logical address", logical.value())?;
+        }
+        validate_provenance(configured.provenance())?;
+        if let Some(target) = entry.request_target() {
+            validate_context(target.target().context())?;
+            if let Some(address) = target.target().address() {
+                validate_text("provider target namespace", address.namespace())?;
+                validate_text("provider target value", address.value())?;
+            }
+            validate_provenance(target.provenance())?;
+        }
+        for reference in entry.evidence_references() {
+            validate_text("configured entry evidence reference", reference.as_str())?;
+        }
     }
     Ok(())
 }
@@ -1680,6 +2033,42 @@ mod tests {
         std::env::temp_dir().join(format!("obdentic-vehicle-cache-{label}-{nonce}"))
     }
 
+    fn provider_applicability(source: &str) -> TopologyProviderApplicability {
+        TopologyProviderApplicability::new(
+            TopologyProviderScope::platform("Synthetic Motors", "Test Platform").unwrap(),
+            Provenance::new(source, Confidence::High).unwrap(),
+        )
+    }
+
+    fn configured_provider_entry(
+        source: &str,
+        identity: &str,
+        logical: &str,
+    ) -> InstalledEcuEvidence {
+        InstalledEcuEvidence::new(
+            ProtocolContext::new(Protocol::Uds, AddressingContext::Unknown),
+            ConfiguredController::new(
+                Some(ConfiguredIdentity::new("synthetic-list", identity)),
+                Some(LogicalAddress::new("synthetic-logical", logical)),
+                Provenance::new(source, Confidence::High).unwrap(),
+            )
+            .unwrap(),
+        )
+        .with_evidence_reference(EvidenceReference::new("synthetic entry evidence").unwrap())
+    }
+
+    fn completed_provider(name: &str, entries: Vec<InstalledEcuEvidence>) -> TopologyProviderResult {
+        TopologyProviderResult::new(
+            TopologyProviderId::new(name, 1).unwrap(),
+            provider_applicability("synthetic applicability"),
+            TopologyProviderStatus::Completed,
+            TopologyProviderCoverage::Partial,
+            entries,
+            [EvidenceReference::new("synthetic provider evidence").unwrap()],
+        )
+        .unwrap()
+    }
+
     #[test]
     fn round_trips_sorted_evidence() {
         let root = root("roundtrip");
@@ -1709,7 +2098,7 @@ mod tests {
         let path = root.join("6c6f63616c2d6b6579.tsv");
         assert_eq!(
             fs::read_to_string(path).unwrap(),
-            "OBDENTIC-VEHICLE-CACHE\t4\nlocal_key\tlocal-key\nfirst_seen_ms\t1\nlast_seen_ms\t2\nhistory\tevidence\n"
+            "OBDENTIC-VEHICLE-CACHE\t5\nlocal_key\tlocal-key\nfirst_seen_ms\t1\nlast_seen_ms\t2\nhistory\tevidence\n"
         );
         fs::remove_dir_all(root).unwrap();
     }
@@ -1749,7 +2138,7 @@ mod tests {
         fs::create_dir_all(&root).unwrap();
         fs::write(
             root.join("6c6f63616c2d6b6579.tsv"),
-            "OBDENTIC-VEHICLE-CACHE\t5\nlocal_key\tlocal-key\nfirst_seen_ms\t1\nlast_seen_ms\t1\n",
+            "OBDENTIC-VEHICLE-CACHE\t6\nlocal_key\tlocal-key\nfirst_seen_ms\t1\nlast_seen_ms\t1\n",
         )
         .unwrap();
         assert!(store.load("local-key").is_err());
@@ -1807,6 +2196,169 @@ mod tests {
             .target_mappings()
             .is_empty());
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn round_trips_topology_provider_results_without_promoting_reachability() {
+        let root = root("provider-roundtrip");
+        let store = CacheStore::new(&root);
+        let target_context = ProtocolContext::new(Protocol::Uds, AddressingContext::Physical);
+        let engine = configured_provider_entry("provider engine", "engine", "01")
+            .with_request_target(RequestTargetEvidence::new(
+                RequestTarget::concrete(
+                    target_context,
+                    RequestAddress::new("reviewed-target-space", "engine-target"),
+                ),
+                Provenance::new("independent target mapping", Confidence::Verified).unwrap(),
+            ));
+        let abs = configured_provider_entry("provider abs", "abs", "03");
+        let provider = completed_provider("synthetic.installation-list", vec![engine, abs]);
+        let snapshot = VehicleCacheSnapshot::new([], [], [])
+            .with_topology_provider_results([provider.clone()]);
+        let signature = snapshot.validation_signature();
+        assert!(signature.topology().is_empty());
+        assert!(signature.ecu_capabilities().is_empty());
+        assert!(signature.target_mappings().is_empty());
+
+        store
+            .save(&VehicleCache::with_snapshot(
+                "local-key",
+                1,
+                2,
+                snapshot.clone(),
+                Vec::new(),
+            ))
+            .unwrap();
+        let loaded = store.load("local-key").unwrap().unwrap();
+        assert_eq!(loaded.snapshot(), &snapshot);
+        assert!(loaded.snapshot().topology().is_empty());
+        assert_eq!(loaded.snapshot().topology_provider_results(), &[provider]);
+        let entries = loaded.snapshot().topology_provider_results()[0].entries();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|entry| {
+            entry
+                .to_topology_node()
+                .observed_responders()
+                .is_empty()
+        }));
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|entry| entry.request_target().is_some())
+                .count(),
+            1
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn blocked_ea189_provider_round_trips_as_unknown_empty_evidence() {
+        let root = root("provider-blocked");
+        let store = CacheStore::new(&root);
+        let blocked = TopologyProviderResult::new(
+            TopologyProviderId::new("vw.pq35.gateway-installation-list", 1).unwrap(),
+            TopologyProviderApplicability::new(
+                TopologyProviderScope::platform("Volkswagen", "PQ35 / EA189").unwrap(),
+                Provenance::new(
+                    "docs/research/vw-gateway-installation-list.md",
+                    Confidence::Verified,
+                )
+                .unwrap(),
+            ),
+            TopologyProviderStatus::Blocked,
+            TopologyProviderCoverage::Unknown,
+            [],
+            [EvidenceReference::new("issue #35 negative safety gate").unwrap()],
+        )
+        .unwrap();
+        let snapshot = VehicleCacheSnapshot::default()
+            .with_topology_provider_results([blocked.clone()]);
+        store
+            .save(&VehicleCache::with_snapshot(
+                "local-key",
+                1,
+                1,
+                snapshot,
+                Vec::new(),
+            ))
+            .unwrap();
+        let loaded = store.load("local-key").unwrap().unwrap();
+        assert_eq!(loaded.snapshot().topology_provider_results(), &[blocked]);
+        assert!(loaded.snapshot().topology_provider_results()[0].entries().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn provider_results_are_sorted_deterministically() {
+        let first = completed_provider(
+            "synthetic.first",
+            vec![configured_provider_entry("first", "engine", "01")],
+        );
+        let second = completed_provider(
+            "synthetic.second",
+            vec![configured_provider_entry("second", "abs", "03")],
+        );
+        let left = VehicleCacheSnapshot::default()
+            .with_topology_provider_results([second.clone(), first.clone()]);
+        let right = VehicleCacheSnapshot::default()
+            .with_topology_provider_results([first, second]);
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn loads_v4_cache_without_topology_provider_results() {
+        let root = root("v4");
+        let store = CacheStore::new(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("6c6f63616c2d6b6579.tsv"),
+            "OBDENTIC-VEHICLE-CACHE\t4\nlocal_key\tlocal-key\nfirst_seen_ms\t1\nlast_seen_ms\t1\n",
+        )
+        .unwrap();
+        let loaded = store.load("local-key").unwrap().unwrap();
+        assert!(loaded.snapshot().topology_provider_results().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_malformed_v5_provider_status_coverage() {
+        let root = root("provider-invalid");
+        let store = CacheStore::new(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("6c6f63616c2d6b6579.tsv"),
+            "OBDENTIC-VEHICLE-CACHE\t5\nlocal_key\tlocal-key\nfirst_seen_ms\t1\nlast_seen_ms\t1\ntopology_provider\tsynthetic.blocked\t1\t0\t0\tsafety review\thigh\tblocked\tcomplete\t0\t0\n",
+        )
+        .unwrap();
+        assert!(store.load("local-key").is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_raw_vin_in_topology_provider_metadata() {
+        let vin = "WVWZZZ1JZXW000001";
+        let provider = TopologyProviderResult::new(
+            TopologyProviderId::new(vin, 1).unwrap(),
+            provider_applicability("synthetic applicability"),
+            TopologyProviderStatus::Completed,
+            TopologyProviderCoverage::Partial,
+            [configured_provider_entry("provider", "engine", "01")],
+            [],
+        )
+        .unwrap();
+        let snapshot = VehicleCacheSnapshot::default().with_topology_provider_results([provider]);
+        let root = root("provider-vin");
+        let store = CacheStore::new(&root);
+        assert!(store
+            .save(&VehicleCache::with_snapshot(
+                "local-key",
+                1,
+                1,
+                snapshot,
+                Vec::new(),
+            ))
+            .is_err());
+        assert!(!root.join("6c6f63616c2d6b6579.tsv").exists());
     }
 
     #[test]
@@ -1983,6 +2535,7 @@ mod tests {
         .unwrap();
         let loaded = store.load("local-key").unwrap().unwrap();
         assert!(loaded.snapshot().ecu_identification().is_empty());
+        assert!(loaded.snapshot().topology_provider_results().is_empty());
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -2019,6 +2572,7 @@ mod tests {
         .unwrap();
         let loaded = store.load("local-key").unwrap().unwrap();
         assert!(loaded.snapshot().topology().is_empty());
+        assert!(loaded.snapshot().topology_provider_results().is_empty());
         assert_eq!(loaded.history(), ["old"]);
         fs::remove_dir_all(root).unwrap();
     }

--- a/src/vehicle_cache.rs
+++ b/src/vehicle_cache.rs
@@ -19,8 +19,8 @@ use crate::{
     },
     topology_provider::{
         EvidenceReference, InstalledEcuEvidence, TopologyProviderApplicability,
-        TopologyProviderCoverage, TopologyProviderId, TopologyProviderResult, TopologyProviderScope,
-        TopologyProviderStatus,
+        TopologyProviderCoverage, TopologyProviderId, TopologyProviderResult,
+        TopologyProviderScope, TopologyProviderStatus,
     },
 };
 
@@ -913,14 +913,12 @@ fn encode_topology_provider_result(result: &TopologyProviderResult) -> String {
 }
 
 fn encode_topology_provider_scope(scope: &TopologyProviderScope) -> Vec<String> {
-    let mut fields = vec![
-        if scope.manufacturer_name().is_some() {
-            "1"
-        } else {
-            "0"
-        }
-        .into(),
-    ];
+    let mut fields = vec![if scope.manufacturer_name().is_some() {
+        "1"
+    } else {
+        "0"
+    }
+    .into()];
     if let Some(manufacturer) = scope.manufacturer_name() {
         fields.push(manufacturer.into());
     }
@@ -941,7 +939,14 @@ fn encode_topology_provider_scope(scope: &TopologyProviderScope) -> Vec<String> 
 fn encode_installed_ecu_evidence(entry: &InstalledEcuEvidence) -> Vec<String> {
     let mut fields = encode_context(entry.context()).to_vec();
     let configured = entry.configured_controller();
-    fields.push(if configured.identity().is_some() { "1" } else { "0" }.into());
+    fields.push(
+        if configured.identity().is_some() {
+            "1"
+        } else {
+            "0"
+        }
+        .into(),
+    );
     if let Some(identity) = configured.identity() {
         fields.extend([identity.authority().into(), identity.identifier().into()]);
     }
@@ -957,7 +962,14 @@ fn encode_installed_ecu_evidence(entry: &InstalledEcuEvidence) -> Vec<String> {
         fields.extend([logical.authority().into(), logical.value().into()]);
     }
     fields.extend(encode_provenance(configured.provenance()));
-    fields.push(if entry.request_target().is_some() { "1" } else { "0" }.into());
+    fields.push(
+        if entry.request_target().is_some() {
+            "1"
+        } else {
+            "0"
+        }
+        .into(),
+    );
     if let Some(target) = entry.request_target() {
         fields.extend(encode_target(target.target()));
         fields.extend(encode_provenance(target.provenance()));
@@ -1549,17 +1561,12 @@ fn parse_topology_provider_result(fields: &[String]) -> Result<TopologyProviderR
     )
     .map_err(|error| error.to_string())?;
     let scope = parse_topology_provider_scope(fields, &mut index)?;
-    let applicability = TopologyProviderApplicability::new(scope, parse_provenance(fields, &mut index)?);
-    let status = parse_topology_provider_status(field(
-        fields,
-        &mut index,
-        "topology provider status",
-    )?)?;
-    let coverage = parse_topology_provider_coverage(field(
-        fields,
-        &mut index,
-        "topology provider coverage",
-    )?)?;
+    let applicability =
+        TopologyProviderApplicability::new(scope, parse_provenance(fields, &mut index)?);
+    let status =
+        parse_topology_provider_status(field(fields, &mut index, "topology provider status")?)?;
+    let coverage =
+        parse_topology_provider_coverage(field(fields, &mut index, "topology provider coverage")?)?;
     let reference_count = parse_count(
         fields,
         &mut index,
@@ -1608,11 +1615,16 @@ fn parse_topology_provider_scope(
     };
     match (manufacturer, platform) {
         (None, None) => Ok(TopologyProviderScope::generic()),
-        (Some(manufacturer), None) => TopologyProviderScope::manufacturer(manufacturer)
-            .map_err(|error| error.to_string()),
-        (Some(manufacturer), Some(platform)) => TopologyProviderScope::platform(manufacturer, platform)
-            .map_err(|error| error.to_string()),
-        (None, Some(_)) => Err("vehicle cache topology provider platform has no manufacturer".into()),
+        (Some(manufacturer), None) => {
+            TopologyProviderScope::manufacturer(manufacturer).map_err(|error| error.to_string())
+        }
+        (Some(manufacturer), Some(platform)) => {
+            TopologyProviderScope::platform(manufacturer, platform)
+                .map_err(|error| error.to_string())
+        }
+        (None, Some(_)) => {
+            Err("vehicle cache topology provider platform has no manufacturer".into())
+        }
     }
 }
 
@@ -1637,12 +1649,9 @@ fn parse_installed_ecu_evidence(
     } else {
         None
     };
-    let configured = ConfiguredController::new(
-        identity,
-        logical_address,
-        parse_provenance(fields, index)?,
-    )
-    .map_err(|error| error.to_string())?;
+    let configured =
+        ConfiguredController::new(identity, logical_address, parse_provenance(fields, index)?)
+            .map_err(|error| error.to_string())?;
     let mut entry = InstalledEcuEvidence::new(context, configured);
     if parse_optional_flag(fields, index, "configured request target")? {
         entry = entry.with_request_target(RequestTargetEvidence::new(
@@ -1658,12 +1667,8 @@ fn parse_installed_ecu_evidence(
     )?;
     for _ in 0..reference_count {
         entry = entry.with_evidence_reference(
-            EvidenceReference::new(field(
-                fields,
-                index,
-                "configured entry evidence reference",
-            )?)
-            .map_err(|error| error.to_string())?,
+            EvidenceReference::new(field(fields, index, "configured entry evidence reference")?)
+                .map_err(|error| error.to_string())?,
         );
     }
     Ok(entry)
@@ -1887,6 +1892,12 @@ fn validate_snapshot(snapshot: &VehicleCacheSnapshot) -> Result<(), String> {
 
 fn validate_topology_provider_result(result: &TopologyProviderResult) -> Result<(), String> {
     validate_text("topology provider id", result.id().name())?;
+    if result.evidence_references().len() > MAX_PROVIDER_EVIDENCE_REFERENCES {
+        return Err("vehicle cache topology provider has too many evidence references".into());
+    }
+    if result.entries().len() > MAX_PROVIDER_ENTRIES {
+        return Err("vehicle cache topology provider has too many entries".into());
+    }
     if let Some(manufacturer) = result.applicability().scope().manufacturer_name() {
         validate_text("topology provider manufacturer", manufacturer)?;
     }
@@ -1916,6 +1927,9 @@ fn validate_topology_provider_result(result: &TopologyProviderResult) -> Result<
                 validate_text("provider target value", address.value())?;
             }
             validate_provenance(target.provenance())?;
+        }
+        if entry.evidence_references().len() > MAX_PROVIDER_ENTRY_EVIDENCE_REFERENCES {
+            return Err("vehicle cache configured entry has too many evidence references".into());
         }
         for reference in entry.evidence_references() {
             validate_text("configured entry evidence reference", reference.as_str())?;
@@ -2057,7 +2071,10 @@ mod tests {
         .with_evidence_reference(EvidenceReference::new("synthetic entry evidence").unwrap())
     }
 
-    fn completed_provider(name: &str, entries: Vec<InstalledEcuEvidence>) -> TopologyProviderResult {
+    fn completed_provider(
+        name: &str,
+        entries: Vec<InstalledEcuEvidence>,
+    ) -> TopologyProviderResult {
         TopologyProviderResult::new(
             TopologyProviderId::new(name, 1).unwrap(),
             provider_applicability("synthetic applicability"),
@@ -2235,12 +2252,9 @@ mod tests {
         assert_eq!(loaded.snapshot().topology_provider_results(), &[provider]);
         let entries = loaded.snapshot().topology_provider_results()[0].entries();
         assert_eq!(entries.len(), 2);
-        assert!(entries.iter().all(|entry| {
-            entry
-                .to_topology_node()
-                .observed_responders()
-                .is_empty()
-        }));
+        assert!(entries
+            .iter()
+            .all(|entry| { entry.to_topology_node().observed_responders().is_empty() }));
         assert_eq!(
             entries
                 .iter()
@@ -2271,8 +2285,8 @@ mod tests {
             [EvidenceReference::new("issue #35 negative safety gate").unwrap()],
         )
         .unwrap();
-        let snapshot = VehicleCacheSnapshot::default()
-            .with_topology_provider_results([blocked.clone()]);
+        let snapshot =
+            VehicleCacheSnapshot::default().with_topology_provider_results([blocked.clone()]);
         store
             .save(&VehicleCache::with_snapshot(
                 "local-key",
@@ -2284,7 +2298,9 @@ mod tests {
             .unwrap();
         let loaded = store.load("local-key").unwrap().unwrap();
         assert_eq!(loaded.snapshot().topology_provider_results(), &[blocked]);
-        assert!(loaded.snapshot().topology_provider_results()[0].entries().is_empty());
+        assert!(loaded.snapshot().topology_provider_results()[0]
+            .entries()
+            .is_empty());
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -2300,8 +2316,7 @@ mod tests {
         );
         let left = VehicleCacheSnapshot::default()
             .with_topology_provider_results([second.clone(), first.clone()]);
-        let right = VehicleCacheSnapshot::default()
-            .with_topology_provider_results([first, second]);
+        let right = VehicleCacheSnapshot::default().with_topology_provider_results([first, second]);
         assert_eq!(left, right);
     }
 
@@ -2348,6 +2363,35 @@ mod tests {
         .unwrap();
         let snapshot = VehicleCacheSnapshot::default().with_topology_provider_results([provider]);
         let root = root("provider-vin");
+        let store = CacheStore::new(&root);
+        assert!(store
+            .save(&VehicleCache::with_snapshot(
+                "local-key",
+                1,
+                1,
+                snapshot,
+                Vec::new(),
+            ))
+            .is_err());
+        assert!(!root.join("6c6f63616c2d6b6579.tsv").exists());
+    }
+
+    #[test]
+    fn rejects_provider_evidence_counts_that_cannot_round_trip() {
+        let references = (0..=MAX_PROVIDER_EVIDENCE_REFERENCES)
+            .map(|index| EvidenceReference::new(format!("provider-ref-{index}")).unwrap())
+            .collect::<Vec<_>>();
+        let provider = TopologyProviderResult::new(
+            TopologyProviderId::new("synthetic.too-many-refs", 1).unwrap(),
+            provider_applicability("synthetic applicability"),
+            TopologyProviderStatus::Completed,
+            TopologyProviderCoverage::Partial,
+            [configured_provider_entry("provider", "engine", "01")],
+            references,
+        )
+        .unwrap();
+        let snapshot = VehicleCacheSnapshot::default().with_topology_provider_results([provider]);
+        let root = root("provider-count-bound");
         let store = CacheStore::new(&root);
         assert!(store
             .save(&VehicleCache::with_snapshot(


### PR DESCRIPTION
## Summary

Implements #130, the next persistence slice of #125.

Adds topology-provider evidence to the existing private `VehicleCacheSnapshot` and upgrades new cache writes to schema v5 while retaining backward reads of v1-v4.

## Architecture

The cache now preserves the transport-free domain result directly:

```text
TopologyProviderResult
  -> configured / installed evidence
  -> private VehicleCacheSnapshot v5

functional / targeted response evidence
  -> existing observed topology cache
```

The meanings remain independent. Provider persistence does not create responder observations, reachability, ECU roles, or inferred request targets.

## Cache v5

Schema v5 persists:

- provider ID/version
- applicability scope + provenance
- status + coverage
- result-level evidence references
- configured-controller identity/logical-address evidence + provenance
- entry-level evidence references
- optional `RequestTargetEvidence` only when it already exists independently in the provider result

Provider/result order is normalized deterministically.

## Backward compatibility

The loader keeps explicit v1, v2, v3 and v4 paths. Older cache files deserialize with an empty topology-provider result collection rather than being rejected or reinterpreted.

## Safety / privacy

- no BLE/ELM/CAN/UDS calls
- no provider execution or discovery orchestration
- no VW gateway request
- no logical-address -> request-target conversion
- no role/reachability inference
- provider metadata passes the existing raw-VIN rejection rules
- provider entry/reference counts are bounded while parsing
- malformed status/coverage combinations fail closed through `TopologyProviderResult::new`

The existing `VehicleCacheSnapshot::validation_signature()` remains unchanged and excludes provider installation evidence, so persisted configured ECUs cannot silently become functional reachability/cache-validation evidence.

## Tests

Adds/updates offline coverage for:

- cache v5 write marker
- completed provider round-trip with two configured ECUs
- explicit request-target evidence round-trip without target inference for other entries
- blocked EA189/PQ35 provider round-trip with zero entries and unknown coverage
- deterministic provider ordering
- v4 backward compatibility
- malformed v5 provider status/coverage rejection
- raw VIN rejection in provider metadata
- unchanged validation-signature semantics

Existing cache, index, ECU-identification and routing tests remain in place.

## Documentation

Updates `docs/topology-providers.md` with private vehicle-instance persistence semantics, cache v5/v1-v4 compatibility, privacy validation, unchanged observation-based validation signatures, and the continued #35 EA189/PQ35 negative safety state.

## Main / parallel work

Based directly on current `main` `d971b719b635543d4db812b239ec9c20c1889804`. The diff is limited to `src/vehicle_cache.rs` and `docs/topology-providers.md` and does not overlap open PRs #65, #102 or #105.

Closes #130
Advances #125