### PR TITLE
Probe Mode 09 engine identifiers

### DIFF
--- a/src/ble.rs
+++ b/src/ble.rs
@@ -20,9 +20,10 @@ pub(crate) use crate::elm::{
     PidSupport,
 };
 pub use crate::elm::{
-    DiagnosticResponse, DiagnosticResponseError, DiagnosticResponses, ProtocolNegotiation,
-    ResponderIdentity, SignalSupport, SignalSupportStatus, SupportDiscovery,
-    TargetedDpfProbeRequest, TargetedEcuIdentificationRequest, TargetedReadRequest,
+    mode09_support_bitmap, DiagnosticResponse, DiagnosticResponseError, DiagnosticResponses,
+    Mode09Pid, ProtocolNegotiation, ResponderIdentity, SignalSupport, SignalSupportStatus,
+    SupportDiscovery, TargetedDpfProbeRequest, TargetedEcuIdentificationRequest,
+    TargetedMode09Request, TargetedReadRequest,
 };
 pub(crate) use crate::elm::{ReadEvidenceError, ResponseObservation};
 
@@ -304,6 +305,20 @@ impl SessionClient {
             .into_transaction()
     }
 
+    pub async fn read_mode09(
+        &self,
+        request: TargetedMode09Request,
+    ) -> Result<DiagnosticResponses, String> {
+        let (reply, result) = oneshot::channel();
+        self.sender
+            .send(SessionCommand::ReadMode09 { request, reply })
+            .await
+            .map_err(|_| "diagnostic session is closed".to_string())?;
+        result
+            .await
+            .map_err(|_| "diagnostic session stopped before responding".to_string())?
+    }
+
     /// Execute the closed EA189 DPF UDS probe and return its raw normalized
     /// responses.  Negative or malformed responses are returned as errors,
     /// while the crate-visible evidence variant retains responder payloads.
@@ -410,6 +425,10 @@ enum SessionCommand {
         request: TargetedReadRequest,
         reply: oneshot::Sender<Result<ReadOutcome, String>>,
     },
+    ReadMode09 {
+        request: TargetedMode09Request,
+        reply: oneshot::Sender<Result<DiagnosticResponses, String>>,
+    },
     ReadDpfProbe {
         request: TargetedDpfProbeRequest,
         reply: oneshot::Sender<Result<DpfProbeOutcome, String>>,
@@ -515,6 +534,31 @@ async fn session_actor(
                     reply,
                 )
                 .await;
+            }
+            SessionCommand::ReadMode09 { request, reply } => {
+                if let Some(error) = health.unhealthy() {
+                    let _ = reply.send(Err(error.to_owned()));
+                    continue;
+                }
+                let started = Instant::now();
+                match session.read_mode09(request).await {
+                    Ok(responses) => {
+                        service.observe(started.elapsed());
+                        health.success();
+                        let _ = reply.send(Ok(responses));
+                    }
+                    Err(error) => {
+                        if health.observe(&error) {
+                            let fatal = health.unhealthy().unwrap().to_owned();
+                            session.disconnect_best_effort().await;
+                            disconnect_done = true;
+                            let _ = reply.send(Err(fatal));
+                        } else {
+                            service.observe(started.elapsed());
+                            let _ = reply.send(Err(error));
+                        }
+                    }
+                }
             }
             SessionCommand::ReadDpfProbe { request, reply } => {
                 if let Some(error) = health.unhealthy() {
@@ -832,6 +876,13 @@ impl DiagnosticSession {
             .into_transaction()
     }
 
+    async fn read_mode09(
+        &mut self,
+        request: TargetedMode09Request,
+    ) -> Result<DiagnosticResponses, String> {
+        self.elm_mut()?.read_mode09(&request).await
+    }
+
     async fn read_dpf_probe_with_evidence(
         &mut self,
         request: TargetedDpfProbeRequest,
@@ -1123,6 +1174,9 @@ mod tests {
                     }
                     SessionCommand::ReadTargeted { reply, .. } => {
                         let _ = reply.send(Err("targeted test request not scripted".into()));
+                    }
+                    SessionCommand::ReadMode09 { reply, .. } => {
+                        let _ = reply.send(Err("Mode 09 test request not scripted".into()));
                     }
                     SessionCommand::ReadDpfProbe { reply, .. } => {
                         let _ = reply.send(Err("DPF probe test request not scripted".into()));

--- a/src/elm.rs
+++ b/src/elm.rs
@@ -181,6 +181,49 @@ pub struct TargetedEcuIdentificationRequest {
     expected_responder: ResponderIdentity,
 }
 
+/// The closed standard OBD-II Mode 09 PID set used for engine identification.
+/// Callers cannot construct an arbitrary Mode 09 request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Mode09Pid {
+    SupportedPids,
+    CalibrationId,
+    CalibrationVerificationNumber,
+    EcuName,
+}
+
+impl Mode09Pid {
+    pub const fn pid(self) -> u8 {
+        match self {
+            Self::SupportedPids => 0x00,
+            Self::CalibrationId => 0x04,
+            Self::CalibrationVerificationNumber => 0x06,
+            Self::EcuName => 0x0A,
+        }
+    }
+
+    pub const fn request_bytes(self) -> [u8; 2] {
+        [0x09, self.pid()]
+    }
+
+    pub const fn advertised_by(self, support_bitmap: u32) -> bool {
+        let pid = self.pid();
+        if pid == 0 {
+            return true;
+        }
+        let offset = pid & 0x1f;
+        let shift = if offset == 0 { 0 } else { 32 - offset };
+        support_bitmap & (1 << shift) != 0
+    }
+}
+
+/// A Mode 09 request bound to the confirmed physical engine target.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetedMode09Request {
+    pid: Mode09Pid,
+    target: RequestTarget,
+    expected_responder: ResponderIdentity,
+}
+
 impl TargetedDpfProbeRequest {
     /// Construct a closed EA189 probe from validated engine target evidence.
     pub fn from_mapping(
@@ -288,6 +331,62 @@ impl TargetedEcuIdentificationRequest {
 
     pub fn request_bytes(&self) -> [u8; 3] {
         self.operation.request_bytes()
+    }
+
+    pub fn target(&self) -> &RequestTarget {
+        &self.target
+    }
+
+    pub fn expected_responder(&self) -> &ResponderIdentity {
+        &self.expected_responder
+    }
+}
+
+impl TargetedMode09Request {
+    pub fn from_mapping(
+        pid: Mode09Pid,
+        mapping: &crate::vehicle_knowledge::EcuTargetMapping,
+    ) -> Result<Self, String> {
+        if mapping.role().role() != &crate::topology::EcuRole::Engine {
+            return Err("Mode 09 probes require validated engine target evidence".into());
+        }
+        let target = mapping.target().target().clone();
+        if mapping.expected_responder().context() != target.context() {
+            return Err("Mode 09 target and responder contexts differ".into());
+        }
+        let expected_responder = mapping
+            .expected_responder()
+            .value()
+            .ok_or_else(|| "Mode 09 probes require an expected responder".to_string())?;
+        Self::new(
+            pid,
+            target,
+            ResponderIdentity::ElmHeader(expected_responder.to_owned()),
+        )
+    }
+
+    fn new(
+        pid: Mode09Pid,
+        target: RequestTarget,
+        expected_responder: ResponderIdentity,
+    ) -> Result<Self, String> {
+        validate_request_target(&target)?;
+        validate_elm_header(&expected_responder, "expected responder")?;
+        Ok(Self {
+            pid,
+            target,
+            expected_responder: ResponderIdentity::ElmHeader(
+                expected_responder.as_str().to_ascii_uppercase(),
+            ),
+        })
+    }
+
+    pub const fn pid(&self) -> Mode09Pid {
+        self.pid
+    }
+
+    pub const fn request_bytes(&self) -> [u8; 2] {
+        self.pid.request_bytes()
     }
 
     pub fn target(&self) -> &RequestTarget {
@@ -685,6 +784,42 @@ where
         request: &TargetedReadRequest,
     ) -> Result<ReadEvidence, ReadEvidenceError> {
         read_elm_targeted_with_evidence(&mut self.exchange, request).await
+    }
+
+    pub(crate) async fn read_mode09(
+        &mut self,
+        request: &TargetedMode09Request,
+    ) -> Result<DiagnosticResponses, String> {
+        if let Err(error) = configure_target(
+            &mut self.exchange,
+            request.target(),
+            request.expected_responder(),
+        )
+        .await
+        {
+            let restore = restore_functional(&mut self.exchange).await;
+            return Err(combine_setup_errors(error, restore));
+        }
+
+        let read = read_elm_mode09_responses(&mut self.exchange, request).await;
+        let read = match read {
+            Ok(responses) => match targeted_payload(&responses, request.expected_responder()) {
+                Ok(_) => Ok(responses),
+                Err(error) => Err(error),
+            },
+            Err(error) => Err(error),
+        };
+        let restore = restore_functional(&mut self.exchange).await;
+        match (read, restore) {
+            (Ok(responses), Ok(())) => Ok(responses),
+            (Err(error), Ok(())) => Err(error),
+            (Ok(_), Err(error)) => Err(format!(
+                "Mode 09 read succeeded; restoring functional addressing failed: {error}"
+            )),
+            (Err(error), Err(restore)) => Err(format!(
+                "{error}; restoring functional addressing failed: {restore}"
+            )),
+        }
     }
 
     pub(crate) async fn read_stored_dtcs(&mut self) -> Result<DiagnosticResponses, String> {
@@ -1107,6 +1242,19 @@ where
     normalize_uds_responses(&response, request.did())
 }
 
+pub(crate) async fn read_elm_mode09_responses<E>(
+    exchange: &mut E,
+    request: &TargetedMode09Request,
+) -> Result<DiagnosticResponses, String>
+where
+    E: ElmExchange,
+{
+    let [_, pid] = request.request_bytes();
+    let command = format!("09{pid:02X}\r");
+    let response = exchange.exchange(&command, COMMAND_TIMEOUT).await?;
+    normalize_mode09_responses(&response, pid)
+}
+
 #[cfg(test)]
 pub(crate) fn supports_pid(support: &PidSupport, pid: u8) -> bool {
     support.supports_pid(pid)
@@ -1130,6 +1278,275 @@ fn obd_command(request: ReadRequest) -> String {
 pub(crate) fn uds_command(operation: crate::protocol::ReadOperation) -> String {
     let [service, high, low] = operation.request_bytes();
     format!("{service:02X}{high:02X}{low:02X}\r")
+}
+
+pub fn mode09_support_bitmap(payload: &[u8]) -> Result<u32, String> {
+    if payload.len() != 6 || payload[..2] != [0x49, 0x00] {
+        return Err("malformed Mode 09 PID 00 response".into());
+    }
+    Ok(u32::from_be_bytes(payload[2..].try_into().unwrap()))
+}
+
+/// Normalize one standard OBD-II Mode 09 response while retaining responder
+/// identity.  Only the requested positive `49 <pid>` payloads become reads;
+/// stale Mode 01 frames are recorded as ignored parser errors.
+pub(crate) fn normalize_mode09_responses(
+    response: &str,
+    pid: u8,
+) -> Result<DiagnosticResponses, String> {
+    let mut matches = Vec::new();
+    let mut errors = Vec::new();
+    let mut assemblies: Vec<(Option<ResponderIdentity>, UdsIsoTpAssembly)> = Vec::new();
+    let request_echo = format!("09{pid:02X}");
+
+    for raw_line in response.split(['\r', '\n']) {
+        let line = raw_line.trim().trim_end_matches('>').trim();
+        if line.is_empty()
+            || line.eq_ignore_ascii_case(&request_echo)
+            || line.to_ascii_uppercase().starts_with("SEARCHING")
+            || (line.to_ascii_uppercase().starts_with("BUS INIT")
+                && !line.to_ascii_uppercase().contains("ERROR"))
+        {
+            continue;
+        }
+        let upper = line.to_ascii_uppercase();
+        let tokens = line.split_ascii_whitespace().collect::<Vec<_>>();
+        let header = tokens.first().filter(|token| token.len() == 3).copied();
+        let responder =
+            header.map(|value| ResponderIdentity::ElmHeader(value.to_ascii_uppercase()));
+        let data = if header.is_some() {
+            &tokens[1..]
+        } else {
+            tokens.as_slice()
+        };
+        if ["?", "NO DATA", "STOPPED", "UNABLE TO CONNECT", "ERROR"]
+            .iter()
+            .any(|status| upper == *status || upper.contains(status))
+        {
+            errors.push(DiagnosticResponseError {
+                responder,
+                error: format!("ELM327 rejected Mode 09 PID {pid:02X} response: {line}"),
+            });
+            continue;
+        }
+        if header.is_some_and(|value| !value.bytes().all(|byte| byte.is_ascii_hexdigit())) {
+            errors.push(DiagnosticResponseError {
+                responder: None,
+                error: format!("malformed ELM327 Mode 09 responder header: {line:?}"),
+            });
+            continue;
+        }
+        let mut bytes = Vec::new();
+        let mut malformed = None;
+        for token in data {
+            if token.is_empty()
+                || token.len() % 2 != 0
+                || !token.bytes().all(|byte| byte.is_ascii_hexdigit())
+            {
+                malformed = Some(format!("malformed ELM327 Mode 09 response line: {line:?}"));
+                break;
+            }
+            for pair in token.as_bytes().as_chunks::<2>().0 {
+                let pair = std::str::from_utf8(pair).expect("ASCII hex token");
+                match u8::from_str_radix(pair, 16) {
+                    Ok(byte) => bytes.push(byte),
+                    Err(error) => {
+                        malformed = Some(error.to_string());
+                        break;
+                    }
+                }
+            }
+            if malformed.is_some() {
+                break;
+            }
+        }
+        if let Some(error) = malformed {
+            errors.push(DiagnosticResponseError { responder, error });
+            continue;
+        }
+
+        let is_mode01 = bytes.first() == Some(&0x41)
+            || (bytes.first().is_some_and(|byte| byte >> 4 == 0) && bytes.get(1) == Some(&0x41));
+        if is_mode01 {
+            errors.push(DiagnosticResponseError {
+                responder: None,
+                error: format!(
+                    "ignored unrelated OBD-II Mode 01 response while awaiting 090{pid:X}: {line:?}"
+                ),
+            });
+            continue;
+        }
+
+        match bytes.first().map(|byte| byte >> 4) {
+            Some(0) => {
+                let declared_len = (bytes[0] & 0x0f) as usize;
+                let payload = &bytes[1..];
+                if declared_len == 0 || payload.len() < declared_len {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("malformed Mode 09 single frame: {line:?}"),
+                    });
+                    continue;
+                }
+                if payload[declared_len..]
+                    .iter()
+                    .any(|byte| !matches!(byte, 0x00 | 0x55 | 0xaa))
+                {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("unexpected bytes after Mode 09 response: {line:?}"),
+                    });
+                    continue;
+                }
+                push_mode09_payload(
+                    &mut matches,
+                    &mut errors,
+                    responder,
+                    &payload[..declared_len],
+                    pid,
+                    line,
+                );
+            }
+            Some(1) => {
+                if bytes.len() < 3 {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("malformed Mode 09 first frame: {line:?}"),
+                    });
+                    continue;
+                }
+                let declared_len = (((bytes[0] & 0x0f) as usize) << 8) | bytes[1] as usize;
+                let payload = &bytes[2..];
+                if declared_len < 3 || payload.len() >= declared_len {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("malformed Mode 09 first frame: {line:?}"),
+                    });
+                    continue;
+                }
+                assemblies.push((
+                    responder,
+                    UdsIsoTpAssembly {
+                        declared_len,
+                        payload: payload.to_vec(),
+                        next_sequence: 1,
+                    },
+                ));
+            }
+            Some(2) => {
+                let Some(index) = assemblies
+                    .iter()
+                    .position(|(identity, _)| *identity == responder)
+                else {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("Mode 09 consecutive frame without first frame: {line:?}"),
+                    });
+                    continue;
+                };
+                if bytes.len() < 2 {
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("malformed Mode 09 consecutive frame: {line:?}"),
+                    });
+                    continue;
+                }
+                let sequence = bytes[0] & 0x0f;
+                let (declared_len, received_len, expected) = {
+                    let assembly = &assemblies[index].1;
+                    (
+                        assembly.declared_len,
+                        assembly.payload.len(),
+                        assembly.next_sequence,
+                    )
+                };
+                if sequence != expected || received_len >= declared_len {
+                    let (responder, _) = assemblies.remove(index);
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("malformed Mode 09 consecutive frame: {line:?}"),
+                    });
+                    continue;
+                }
+                let data = &bytes[1..];
+                let remaining = declared_len - received_len;
+                if data.len() > remaining
+                    && data[remaining..]
+                        .iter()
+                        .any(|byte| !matches!(byte, 0x00 | 0x55 | 0xaa))
+                {
+                    let (responder, _) = assemblies.remove(index);
+                    errors.push(DiagnosticResponseError {
+                        responder,
+                        error: format!("unexpected bytes after Mode 09 response: {line:?}"),
+                    });
+                    continue;
+                }
+                let complete = {
+                    let assembly = &mut assemblies[index].1;
+                    assembly
+                        .payload
+                        .extend_from_slice(&data[..data.len().min(remaining)]);
+                    assembly.next_sequence = (sequence + 1) & 0x0f;
+                    assembly.payload.len() == declared_len
+                };
+                if complete {
+                    let (responder, assembly) = assemblies.remove(index);
+                    push_mode09_payload(
+                        &mut matches,
+                        &mut errors,
+                        responder,
+                        &assembly.payload,
+                        pid,
+                        line,
+                    );
+                }
+            }
+            Some(3) => errors.push(DiagnosticResponseError {
+                responder,
+                error: format!("unexpected Mode 09 flow-control frame: {line:?}"),
+            }),
+            _ => push_mode09_payload(&mut matches, &mut errors, responder, &bytes, pid, line),
+        }
+    }
+    for (responder, assembly) in assemblies {
+        errors.push(DiagnosticResponseError {
+            responder,
+            error: format!(
+                "truncated Mode 09 response: declared {} bytes, received {}",
+                assembly.declared_len,
+                assembly.payload.len()
+            ),
+        });
+    }
+    if matches.is_empty() && errors.is_empty() {
+        errors.push(DiagnosticResponseError {
+            responder: None,
+            error: format!("Mode 09 PID {pid:02X} response not found"),
+        });
+    }
+    Ok(DiagnosticResponses::with_errors(matches, response, errors))
+}
+
+fn push_mode09_payload(
+    matches: &mut Vec<DiagnosticResponse>,
+    errors: &mut Vec<DiagnosticResponseError>,
+    responder: Option<ResponderIdentity>,
+    payload: &[u8],
+    pid: u8,
+    line: &str,
+) {
+    if payload.starts_with(&[0x49, pid]) {
+        matches.push(DiagnosticResponse {
+            responder,
+            payload: payload.to_vec(),
+        });
+    } else {
+        errors.push(DiagnosticResponseError {
+            responder,
+            error: format!("unexpected Mode 09 PID {pid:02X} response: {line:?}"),
+        });
+    }
 }
 
 #[cfg(test)]
@@ -2539,5 +2956,34 @@ mod tests {
             .error
             .contains("ignored unrelated OBD-II Mode 01 response"));
         assert!(responses.raw_response().contains("41 00 98 3B A0 13"));
+    }
+
+    #[test]
+    fn mode09_support_bitmap_gates_only_the_closed_pid_set() {
+        let bitmap = mode09_support_bitmap(&[0x49, 0x00, 0x14, 0x40, 0x00, 0x00]).unwrap();
+
+        assert!(Mode09Pid::CalibrationId.advertised_by(bitmap));
+        assert!(Mode09Pid::CalibrationVerificationNumber.advertised_by(bitmap));
+        assert!(Mode09Pid::EcuName.advertised_by(bitmap));
+        assert_eq!(Mode09Pid::EcuName.request_bytes(), [0x09, 0x0A]);
+        assert!(mode09_support_bitmap(&[0x49, 0x00, 0x14]).is_err());
+    }
+
+    #[test]
+    fn mode09_normalizer_keeps_the_target_responder_and_reassembles_frames() {
+        let responses = normalize_mode09_responses(
+            "7E8 10 0C 49 04 01 43 41 4C\r7E8 21 49 44 31 32 33 34 55\r>",
+            0x04,
+        )
+        .unwrap();
+
+        assert_eq!(
+            responses.as_slice(),
+            &[DiagnosticResponse {
+                responder: Some(ResponderIdentity::ElmHeader("7E8".into())),
+                payload: b"I\x04\x01CALID1234".to_vec(),
+            }]
+        );
+        assert!(responses.errors().is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic diagnose ea189.dpf.probe --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle scan --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture --adapter <CoreBluetooth UUID> --profile ea189-dpf --record <capture.jsonl> --cycles <1..=1440> --interval-seconds <>=30> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic capture dpf-report <capture.jsonl>... | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
+const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic diagnose ea189.dpf.probe --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle scan --adapter <CoreBluetooth UUID> | obdentic vehicle mode09 --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture --adapter <CoreBluetooth UUID> --profile ea189-dpf --record <capture.jsonl> --cycles <1..=1440> --interval-seconds <>=30> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic capture dpf-report <capture.jsonl>... | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
 
 #[derive(Debug, PartialEq, Eq)]
 enum Command {
@@ -71,6 +71,9 @@ enum Command {
         adapter_id: String,
     },
     VehicleScan {
+        adapter_id: String,
+    },
+    VehicleMode09 {
         adapter_id: String,
     },
     VehicleShow,
@@ -194,6 +197,9 @@ async fn run() -> Result<(), String> {
             }
             Command::VehicleScan { adapter_id } => {
                 run_vehicle_scan(&adapter_id, &runtime, &mut runtime_state).await
+            }
+            Command::VehicleMode09 { adapter_id } => {
+                run_vehicle_mode09(&adapter_id, &runtime, &mut runtime_state).await
             }
             Command::VehicleShow => run_vehicle_show(),
             Command::Capture {
@@ -572,6 +578,105 @@ async fn run_vehicle_scan_inner(adapter_id: &str) -> Result<(), String> {
     .await;
     let shutdown = session.shutdown().await;
     scan?;
+    shutdown
+}
+
+async fn run_vehicle_mode09(
+    adapter_id: &str,
+    runtime: &RuntimeClient,
+    state: &mut RuntimeState,
+) -> Result<(), String> {
+    apply_runtime_event(
+        runtime,
+        state,
+        None,
+        RuntimeEvent::source(SourceState::Live),
+    )
+    .await?;
+    apply_runtime_event(
+        runtime,
+        state,
+        None,
+        RuntimeEvent::transport(TransportState::Connecting),
+    )
+    .await?;
+    apply_runtime_event(runtime, state, None, RuntimeEvent::DiscoveryStarted).await?;
+
+    match run_vehicle_mode09_inner(adapter_id).await {
+        Ok(()) => {
+            apply_runtime_event(runtime, state, None, RuntimeEvent::DiscoveryCompleted).await?;
+            apply_runtime_event(
+                runtime,
+                state,
+                None,
+                RuntimeEvent::transport(TransportState::Disconnected),
+            )
+            .await
+        }
+        Err(error) => {
+            finish_discovery_failure(&error, runtime, state).await?;
+            Err(error)
+        }
+    }
+}
+
+async fn run_vehicle_mode09_inner(adapter_id: &str) -> Result<(), String> {
+    let mapping = cached_engine_mapping(adapter_id).await?;
+    let session = ble::start_session(adapter_id).await?;
+    let expected = mapping
+        .expected_responder()
+        .value()
+        .ok_or_else(|| "engine mapping has no expected responder".to_string())?;
+    let expected = ble::ResponderIdentity::ElmHeader(expected.to_owned());
+    let result: Result<(), String> = async {
+        let support = session
+            .read_mode09(ble::TargetedMode09Request::from_mapping(
+                ble::Mode09Pid::SupportedPids,
+                &mapping,
+            )?)
+            .await?;
+        let support_payload = support.select(&expected)?;
+        let support_bitmap = ble::mode09_support_bitmap(&support_payload)?;
+        println!("vehicle mode09");
+        println!(
+            "target\t{}",
+            mapping
+                .target()
+                .target()
+                .address()
+                .map_or("unknown", |address| address.value())
+        );
+        println!("responder\t{}", expected.as_str());
+        println!("pid\t00\tsupported\t{}", hex(&support_payload[2..]));
+
+        for pid in [
+            ble::Mode09Pid::CalibrationId,
+            ble::Mode09Pid::CalibrationVerificationNumber,
+            ble::Mode09Pid::EcuName,
+        ] {
+            if !pid.advertised_by(support_bitmap) {
+                println!("pid\t{:02X}\tnot-advertised\t", pid.pid());
+                continue;
+            }
+            let request = ble::TargetedMode09Request::from_mapping(pid, &mapping)?;
+            match session.read_mode09(request).await {
+                Ok(responses) => match responses.select(&expected) {
+                    Ok(payload) if payload.len() >= 2 && payload[..2] == [0x49, pid.pid()] => {
+                        println!("pid\t{:02X}\tread\t{}", pid.pid(), hex(&payload[2..]));
+                    }
+                    Ok(_) => println!("pid\t{:02X}\terror\tmalformed-response", pid.pid()),
+                    Err(error) => {
+                        println!("pid\t{:02X}\terror\t{}", pid.pid(), escape_field(&error))
+                    }
+                },
+                Err(error) => println!("pid\t{:02X}\terror\t{}", pid.pid(), escape_field(&error)),
+            }
+        }
+        Ok(())
+    }
+    .await;
+    let shutdown = session.shutdown().await;
+    result?;
     shutdown
 }
 
@@ -2552,6 +2657,14 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
                 adapter_id: adapter_id.clone(),
             })
         }
+        [command, action, adapter_flag, adapter_id]
+            if command == "vehicle" && action == "mode09" && adapter_flag == "--adapter" =>
+        {
+            require_uuid(adapter_id)?;
+            Ok(Command::VehicleMode09 {
+                adapter_id: adapter_id.clone(),
+            })
+        }
         [command, action] if command == "vehicle" && action == "show" => Ok(Command::VehicleShow),
         [command] if command == "demo" => Ok(Command::Demo),
         [command, adapter_flag, adapter_id, profile_flag, profile_name, record_flag, path]
@@ -2987,6 +3100,12 @@ mod tests {
         assert_eq!(
             parse_command(&args(&["vehicle", "scan", "--adapter", uuid,])),
             Ok(Command::VehicleScan {
+                adapter_id: uuid.into(),
+            })
+        );
+        assert_eq!(
+            parse_command(&args(&["vehicle", "mode09", "--adapter", uuid,])),
+            Ok(Command::VehicleMode09 {
                 adapter_id: uuid.into(),
             })
         );


### PR DESCRIPTION
Implements #129. Adds a closed physical engine Mode 09 probe: 0900, then only advertised 0904, 0906, and 090A. The command requires the existing validated engine mapping and restores functional addressing after every read. Hardware acceptance remains pending.