### PR TITLE
Show adapter IO for Mode 09 probes

### DIFF
--- a/src/ble.rs
+++ b/src/ble.rs
@@ -245,6 +245,13 @@ pub async fn start_session(adapter_id: &str) -> Result<SessionClient, String> {
     start_session_mode(adapter_id, true).await
 }
 
+/// Start the same closed session while mirroring adapter TX/RX for a bounded
+/// diagnostic probe. No caller-controlled ELM command path is exposed.
+pub async fn start_session_with_adapter_io(adapter_id: &str) -> Result<SessionClient, String> {
+    let session = DiagnosticSession::connect_with_adapter_io_mode(adapter_id, true, true).await?;
+    Ok(start_session_actor(session))
+}
+
 async fn start_session_mode(
     adapter_id: &str,
     discover_support: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -622,7 +622,7 @@ async fn run_vehicle_mode09(
 
 async fn run_vehicle_mode09_inner(adapter_id: &str) -> Result<(), String> {
     let mapping = cached_engine_mapping(adapter_id).await?;
-    let session = ble::start_session(adapter_id).await?;
+    let session = ble::start_session_with_adapter_io(adapter_id).await?;
     let expected = mapping
         .expected_responder()
         .value()


### PR DESCRIPTION
Follow-up for #129: mirrors existing Carly TX/RX only for the bounded vehicle mode09 probe, so unavailable identifier reads remain inspectable.