### PR TITLE
Probe functional F18C responders

### DIFF
--- a/src/ble.rs
+++ b/src/ble.rs
@@ -21,9 +21,9 @@ pub(crate) use crate::elm::{
 };
 pub use crate::elm::{
     mode09_support_bitmap, DiagnosticResponse, DiagnosticResponseError, DiagnosticResponses,
-    Mode09Pid, ProtocolNegotiation, ResponderIdentity, SignalSupport, SignalSupportStatus,
-    SupportDiscovery, TargetedDpfProbeRequest, TargetedEcuIdentificationRequest,
-    TargetedMode09Request, TargetedReadRequest,
+    FunctionalEcuSerialProbe, Mode09Pid, ProtocolNegotiation, ResponderIdentity, SignalSupport,
+    SignalSupportStatus, SupportDiscovery, TargetedDpfProbeRequest,
+    TargetedEcuIdentificationRequest, TargetedMode09Request, TargetedReadRequest,
 };
 pub(crate) use crate::elm::{ReadEvidenceError, ResponseObservation};
 
@@ -361,6 +361,21 @@ impl SessionClient {
             .into_result()
     }
 
+    /// Execute a closed, standards-catalogued functional identification read.
+    pub async fn read_functional_ecu_serials(
+        &self,
+        probe: FunctionalEcuSerialProbe,
+    ) -> Result<DiagnosticResponses, String> {
+        let (reply, result) = oneshot::channel();
+        self.sender
+            .send(SessionCommand::ReadFunctionalEcuSerials { probe, reply })
+            .await
+            .map_err(|_| "diagnostic session is closed".to_string())?;
+        result
+            .await
+            .map_err(|_| "diagnostic session stopped before responding".to_string())?
+    }
+
     pub(crate) async fn read_ecu_identification_with_evidence(
         &self,
         request: TargetedEcuIdentificationRequest,
@@ -443,6 +458,10 @@ enum SessionCommand {
     ReadEcuIdentification {
         request: TargetedEcuIdentificationRequest,
         reply: oneshot::Sender<Result<EcuIdentificationOutcome, String>>,
+    },
+    ReadFunctionalEcuSerials {
+        probe: FunctionalEcuSerialProbe,
+        reply: oneshot::Sender<Result<DiagnosticResponses, String>>,
     },
     ReadStoredDtcs {
         reply: oneshot::Sender<Result<DiagnosticResponses, String>>,
@@ -602,6 +621,31 @@ async fn session_actor(
                     reply,
                 )
                 .await;
+            }
+            SessionCommand::ReadFunctionalEcuSerials { probe, reply } => {
+                if let Some(error) = health.unhealthy() {
+                    let _ = reply.send(Err(error.to_owned()));
+                    continue;
+                }
+                let started = Instant::now();
+                match session.read_functional_ecu_serials(probe).await {
+                    Ok(responses) => {
+                        service.observe(started.elapsed());
+                        health.success();
+                        let _ = reply.send(Ok(responses));
+                    }
+                    Err(error) => {
+                        if health.observe(&error) {
+                            let fatal = health.unhealthy().unwrap().to_owned();
+                            session.disconnect_best_effort().await;
+                            disconnect_done = true;
+                            let _ = reply.send(Err(fatal));
+                        } else {
+                            service.observe(started.elapsed());
+                            let _ = reply.send(Err(error));
+                        }
+                    }
+                }
             }
             SessionCommand::ReadStoredDtcs { reply } => {
                 if let Some(error) = health.unhealthy() {
@@ -940,6 +984,13 @@ impl DiagnosticSession {
         }
     }
 
+    async fn read_functional_ecu_serials(
+        &mut self,
+        probe: FunctionalEcuSerialProbe,
+    ) -> Result<DiagnosticResponses, String> {
+        self.elm_mut()?.read_functional_ecu_serials(&probe).await
+    }
+
     async fn read_stored_dtcs(&mut self) -> Result<DiagnosticResponses, String> {
         self.elm_mut()?.read_stored_dtcs().await
     }
@@ -1191,6 +1242,10 @@ mod tests {
                     SessionCommand::ReadEcuIdentification { reply, .. } => {
                         let _ =
                             reply.send(Err("ECU identification test request not scripted".into()));
+                    }
+                    SessionCommand::ReadFunctionalEcuSerials { reply, .. } => {
+                        let _ = reply
+                            .send(Err("functional ECU serial test request not scripted".into()));
                     }
                     SessionCommand::ReadStoredDtcs { reply } => {
                         let _ = reply.send(Err("stored DTC test request not scripted".into()));

--- a/src/elm.rs
+++ b/src/elm.rs
@@ -181,6 +181,32 @@ pub struct TargetedEcuIdentificationRequest {
     expected_responder: ResponderIdentity,
 }
 
+/// The one closed functional ECU responder probe. It can be built only from
+/// the catalogued standard ECU serial-number candidate.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FunctionalEcuSerialProbe {
+    candidate: crate::ecu_identification::IdentificationCandidate,
+}
+
+impl FunctionalEcuSerialProbe {
+    pub fn from_candidate(
+        candidate: crate::ecu_identification::IdentificationCandidate,
+    ) -> Result<Self, String> {
+        if candidate.did() != 0xF18C || candidate.semantic() != "ecu.serial_number" {
+            return Err("functional ECU responder probing is limited to standard F18C".into());
+        }
+        Ok(Self { candidate })
+    }
+
+    pub const fn request_bytes(&self) -> [u8; 3] {
+        self.candidate.request_bytes()
+    }
+
+    fn candidate(&self) -> &crate::ecu_identification::IdentificationCandidate {
+        &self.candidate
+    }
+}
+
 /// The closed standard OBD-II Mode 09 PID set used for engine identification.
 /// Callers cannot construct an arbitrary Mode 09 request.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -926,6 +952,15 @@ where
             }
         }
     }
+
+    /// Execute one standards-catalogued functional ECU-identification read.
+    /// The candidate type has no caller-supplied DID constructor.
+    pub(crate) async fn read_functional_ecu_serials(
+        &mut self,
+        probe: &FunctionalEcuSerialProbe,
+    ) -> Result<DiagnosticResponses, String> {
+        read_elm_functional_ecu_serial_responses(&mut self.exchange, probe).await
+    }
 }
 
 fn should_retry_stale_uds_response(responses: &DiagnosticResponses) -> bool {
@@ -1240,6 +1275,36 @@ where
     let command = uds_command(request.operation);
     let response = exchange.exchange(&command, COMMAND_TIMEOUT).await?;
     normalize_uds_responses(&response, request.did())
+}
+
+pub(crate) async fn read_elm_functional_ecu_serial_responses<E>(
+    exchange: &mut E,
+    probe: &FunctionalEcuSerialProbe,
+) -> Result<DiagnosticResponses, String>
+where
+    E: ElmExchange,
+{
+    let candidate = probe.candidate();
+    let command = uds_command(candidate.operation());
+    let response = exchange.exchange(&command, COMMAND_TIMEOUT).await?;
+    let responses = normalize_uds_responses(&response, candidate.did())?;
+    let mut accepted = Vec::new();
+    let mut errors = responses.errors;
+    for response in responses.responses {
+        if response.payload.starts_with(&[0x62, 0xF1, 0x8C]) {
+            accepted.push(response);
+        } else {
+            errors.push(DiagnosticResponseError {
+                responder: response.responder,
+                error: "unexpected response while awaiting UDS 22 F18C".into(),
+            });
+        }
+    }
+    Ok(DiagnosticResponses::with_errors(
+        accepted,
+        &responses.raw_response,
+        errors,
+    ))
 }
 
 pub(crate) async fn read_elm_mode09_responses<E>(
@@ -2791,6 +2856,37 @@ mod tests {
                 "ATCRA\r",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn functional_f18c_keeps_only_positive_responder_identity() {
+        let catalog =
+            crate::knowledge_db::KnowledgeCatalog::load_pinned(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let candidate = crate::ecu_identification::EcuIdentificationPlan::from_catalog(&catalog)
+            .unwrap()
+            .candidates()
+            .iter()
+            .find(|candidate| candidate.did() == 0xF18C)
+            .unwrap()
+            .clone();
+        let probe = FunctionalEcuSerialProbe::from_candidate(candidate).unwrap();
+        let exchange =
+            ScriptedExchange::new(["7E8 05 62 F1 8C 01 02 55 55\r7E9 03 7F 22 31 55 55\r>"]);
+        let mut session = ElmSession::new(exchange);
+
+        let responses = session.read_functional_ecu_serials(&probe).await.unwrap();
+
+        assert_eq!(responses.as_slice().len(), 1);
+        assert_eq!(
+            responses.as_slice()[0].responder,
+            Some(ResponderIdentity::ElmHeader("7E8".into()))
+        );
+        assert_eq!(
+            responses.as_slice()[0].payload,
+            [0x62, 0xF1, 0x8C, 0x01, 0x02]
+        );
+        assert_eq!(responses.errors().len(), 1);
+        assert_eq!(session.into_exchange().commands, ["22F18C\r"]);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic diagnose ea189.dpf.probe --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle scan --adapter <CoreBluetooth UUID> | obdentic vehicle mode09 --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture --adapter <CoreBluetooth UUID> --profile ea189-dpf --record <capture.jsonl> --cycles <1..=1440> --interval-seconds <>=30> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic capture dpf-report <capture.jsonl>... | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
+const USAGE: &str = "usage: obdentic signals | obdentic signals --adapter <CoreBluetooth UUID> --supported | obdentic scan | obdentic diagnose dtc.scan --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic diagnose ea189.dpf.probe --adapter <CoreBluetooth UUID> [--record capture.jsonl] | obdentic vehicle identify --adapter <CoreBluetooth UUID> | obdentic vehicle discover --adapter <CoreBluetooth UUID> | obdentic vehicle refresh --adapter <CoreBluetooth UUID> | obdentic vehicle scan --adapter <CoreBluetooth UUID> | obdentic vehicle mode09 --adapter <CoreBluetooth UUID> | obdentic vehicle ecu-serials --adapter <CoreBluetooth UUID> | obdentic vehicle show | obdentic read <signal> --adapter <CoreBluetooth UUID> [--record recording.tsv] | obdentic capture --adapter <CoreBluetooth UUID> --profile <profile> --record <capture.jsonl> | obdentic capture --adapter <CoreBluetooth UUID> --profile ea189-dpf --record <capture.jsonl> --cycles <1..=1440> --interval-seconds <>=30> | obdentic capture inspect <capture.jsonl> | obdentic capture capability <capture.jsonl> | obdentic capture dpf-report <capture.jsonl>... | obdentic demo | obdentic replay <recording.tsv> | obdentic layout save engine-overview <layout.tsv> | obdentic tui demo [--layout layout.tsv] | obdentic tui replay <recording.tsv> [--layout layout.tsv] | obdentic tui capture <capture.jsonl> [--layout layout.tsv] | obdentic tui live --adapter <CoreBluetooth UUID> [--layout layout.tsv] [--record capture.jsonl]";
 
 #[derive(Debug, PartialEq, Eq)]
 enum Command {
@@ -74,6 +74,9 @@ enum Command {
         adapter_id: String,
     },
     VehicleMode09 {
+        adapter_id: String,
+    },
+    VehicleEcuSerials {
         adapter_id: String,
     },
     VehicleShow,
@@ -200,6 +203,9 @@ async fn run() -> Result<(), String> {
             }
             Command::VehicleMode09 { adapter_id } => {
                 run_vehicle_mode09(&adapter_id, &runtime, &mut runtime_state).await
+            }
+            Command::VehicleEcuSerials { adapter_id } => {
+                run_vehicle_ecu_serials(&adapter_id, &runtime, &mut runtime_state).await
             }
             Command::VehicleShow => run_vehicle_show(),
             Command::Capture {
@@ -671,6 +677,88 @@ async fn run_vehicle_mode09_inner(adapter_id: &str) -> Result<(), String> {
                 },
                 Err(error) => println!("pid\t{:02X}\terror\t{}", pid.pid(), escape_field(&error)),
             }
+        }
+        Ok(())
+    }
+    .await;
+    let shutdown = session.shutdown().await;
+    result?;
+    shutdown
+}
+
+async fn run_vehicle_ecu_serials(
+    adapter_id: &str,
+    runtime: &RuntimeClient,
+    state: &mut RuntimeState,
+) -> Result<(), String> {
+    apply_runtime_event(
+        runtime,
+        state,
+        None,
+        RuntimeEvent::source(SourceState::Live),
+    )
+    .await?;
+    apply_runtime_event(
+        runtime,
+        state,
+        None,
+        RuntimeEvent::transport(TransportState::Connecting),
+    )
+    .await?;
+    apply_runtime_event(runtime, state, None, RuntimeEvent::DiscoveryStarted).await?;
+
+    match run_vehicle_ecu_serials_inner(adapter_id).await {
+        Ok(()) => {
+            apply_runtime_event(runtime, state, None, RuntimeEvent::DiscoveryCompleted).await?;
+            apply_runtime_event(
+                runtime,
+                state,
+                None,
+                RuntimeEvent::transport(TransportState::Disconnected),
+            )
+            .await
+        }
+        Err(error) => {
+            finish_discovery_failure(&error, runtime, state).await?;
+            Err(error)
+        }
+    }
+}
+
+async fn run_vehicle_ecu_serials_inner(adapter_id: &str) -> Result<(), String> {
+    let catalog = KnowledgeCatalog::load_pinned(Path::new(env!("CARGO_MANIFEST_DIR")))
+        .map_err(|error| error.to_string())?;
+    let candidate = EcuIdentificationPlan::from_catalog(&catalog)?
+        .candidates()
+        .iter()
+        .find(|candidate| candidate.did() == 0xF18C)
+        .cloned()
+        .ok_or_else(|| "canonical knowledge is missing standard F18C".to_string())?;
+    let probe = ble::FunctionalEcuSerialProbe::from_candidate(candidate)?;
+    let session = ble::start_session(adapter_id).await?;
+    let result: Result<(), String> = async {
+        let responses = session.read_functional_ecu_serials(probe).await?;
+        println!("vehicle ecu serial responders");
+        println!("request\t22 F1 8C");
+        println!("responders\t{}", responses.as_slice().len());
+        for response in responses.as_slice() {
+            println!(
+                "responder\t{}\tpositive",
+                response
+                    .responder
+                    .as_ref()
+                    .map_or("unknown", ble::ResponderIdentity::as_str)
+            );
+        }
+        for error in responses.errors() {
+            println!(
+                "responder\t{}\terror\t{}",
+                error
+                    .responder
+                    .as_ref()
+                    .map_or("unknown", ble::ResponderIdentity::as_str),
+                escape_field(&error.error)
+            );
         }
         Ok(())
     }
@@ -2665,6 +2753,14 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
                 adapter_id: adapter_id.clone(),
             })
         }
+        [command, action, adapter_flag, adapter_id]
+            if command == "vehicle" && action == "ecu-serials" && adapter_flag == "--adapter" =>
+        {
+            require_uuid(adapter_id)?;
+            Ok(Command::VehicleEcuSerials {
+                adapter_id: adapter_id.clone(),
+            })
+        }
         [command, action] if command == "vehicle" && action == "show" => Ok(Command::VehicleShow),
         [command] if command == "demo" => Ok(Command::Demo),
         [command, adapter_flag, adapter_id, profile_flag, profile_name, record_flag, path]
@@ -3106,6 +3202,12 @@ mod tests {
         assert_eq!(
             parse_command(&args(&["vehicle", "mode09", "--adapter", uuid,])),
             Ok(Command::VehicleMode09 {
+                adapter_id: uuid.into(),
+            })
+        );
+        assert_eq!(
+            parse_command(&args(&["vehicle", "ecu-serials", "--adapter", uuid,])),
+            Ok(Command::VehicleEcuSerials {
                 adapter_id: uuid.into(),
             })
         );


### PR DESCRIPTION
Implements #134. Adds one closed functional UDS 22 F1 8C responder probe. It accepts only positive 62 F1 8C replies, preserves responder identity, reports stale/malformed/negative responses as errors, and never renders ECU serial bytes.