### PR TITLE
Fix parallel Effective Knowledge fixture isolation

### DIFF
--- a/tests/effective_knowledge.rs
+++ b/tests/effective_knowledge.rs
@@ -6,17 +6,24 @@ use obdentic::{
         FingerprintField, KnowledgeCatalog, KnowledgePin, CANONICAL_KNOWLEDGE_REPOSITORY,
     },
 };
-use std::{fs, path::PathBuf, time::SystemTime};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+    time::SystemTime,
+};
 
 const FIXTURE_REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
+static TEMP_DIR_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 fn temp_dir() -> PathBuf {
     let nonce = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
+    let sequence = TEMP_DIR_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     let path = std::env::temp_dir().join(format!(
-        "obdentic-effective-knowledge-{}-{nonce}",
+        "obdentic-effective-knowledge-{}-{nonce}-{sequence}",
         std::process::id()
     ));
     fs::create_dir_all(path.join("manufacturers/test")).unwrap();


### PR DESCRIPTION
## Summary

Fixes the nondeterministic temporary-directory collision in `tests/effective_knowledge.rs` that has repeatedly broken unrelated PR CI under parallel test execution.

Closes #145.
Unblocks #144.

## Change

The existing test helper used only process ID plus `SystemTime::now().as_nanos()` for fixture paths. On current macOS runners, parallel tests have observed identical timestamps and therefore shared/removal-raced the same fixture directory.

The helper now adds a process-local `AtomicU64` sequence component. Every fixture allocation in the process is unique even if two calls receive the same clock value.

## Scope

- one test file only
- no product code
- no resolver/Knowledge behavior change
- no retry or assertion masking
- cleanup behavior unchanged

## Validation

Normal repository CI is the merge gate. The previous failures were `missing field schema_version` and `EmptyKnowledgeRepository` at the shared fixture helper; an identical no-code rerun had already demonstrated nondeterministic fixture interference.
