### PR TITLE
Configure engineering skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,16 @@ Choose the lowest-cost worker that can reliably handle the task. Give every work
 
 When work is tracked by a GitHub issue, completing that work includes committing its intended changes on a feature branch, opening a pull request, and merging it into `main` only after CI succeeds. Enable auto-merge for a ready pull request so GitHub merges it once its required CI checks pass. Immediately after that successful merge, close the implemented issue. Keep the milestone open when a separately recorded hardware acceptance remains; close it after all its issues and required acceptance work are complete.
 
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues for `frankherchet/obdentic`. See `docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+Single-context layout: `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.
+
 ## Project constraints
 
 - Treat `docs/project-goals.md` as the long-term product contract. If an implementation decision changes those goals, update that document deliberately rather than allowing architecture to drift implicitly.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,12 @@
+# Domain docs
+
+This repository uses a single-context layout.
+
+Before exploring a domain area, read the relevant files when they exist:
+
+- `CONTEXT.md` at the repository root;
+- `docs/adr/` for decisions affecting that area.
+
+If either location does not exist, proceed silently. Create domain documentation only when a term or decision is actually resolved.
+
+Use the terms defined in `CONTEXT.md` consistently in issue titles, refactor proposals, hypotheses and tests. Surface any conflict with an applicable ADR explicitly rather than silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,20 @@
+# Issue tracker: GitHub
+
+Issues and specifications for this repository live in GitHub Issues. Use the `gh` CLI for issue operations.
+
+## Conventions
+
+- Create: `gh issue create --title "..." --body "..."`.
+- Read: `gh issue view <number> --comments`.
+- List: `gh issue list` with the appropriate state and label filters.
+- Comment: `gh issue comment <number> --body "..."`.
+- Label: `gh issue edit <number> --add-label "..."` or `--remove-label "..."`.
+- Close: `gh issue close <number> --comment "..."`.
+
+Infer the repository from `git remote -v`; `gh` does this automatically inside this clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+When a skill says “publish to the issue tracker”, create a GitHub issue. When it says “fetch the relevant ticket”, run `gh issue view <number> --comments`.


### PR DESCRIPTION
Configures GitHub as the issue tracker and documents the single-context domain-doc layout for repository engineering skills.