### PR TITLE
Hide ELM DPF request behind prepared session

### DIFF
--- a/src/ble.rs
+++ b/src/ble.rs
@@ -9,7 +9,6 @@ use tokio::sync::{mpsc, oneshot};
 pub use crate::adapter::AdapterCandidate;
 #[cfg(test)]
 use crate::elm::ElmExchange;
-use crate::elm::ElmSession;
 #[cfg(test)]
 pub(crate) use crate::elm::{
     discover_pid_support as discover_pid_support_with_limit, establish_elm_protocol,
@@ -22,9 +21,10 @@ pub(crate) use crate::elm::{
 pub use crate::elm::{
     mode09_support_bitmap, DiagnosticResponse, DiagnosticResponseError, DiagnosticResponses,
     FunctionalEcuSerialProbe, Mode09Pid, ProtocolNegotiation, ResponderIdentity, SignalSupport,
-    SignalSupportStatus, SupportDiscovery, TargetedDpfProbeRequest,
-    TargetedEcuIdentificationRequest, TargetedMode09Request, TargetedReadRequest,
+    SignalSupportStatus, SupportDiscovery, TargetedEcuIdentificationRequest, TargetedMode09Request,
+    TargetedReadRequest,
 };
+use crate::elm::{ElmSession, TargetedDpfProbeRequest};
 pub(crate) use crate::elm::{ReadEvidenceError, ResponseObservation};
 
 // Two consecutive transport failures stop a live session; data failures reset the count.
@@ -48,9 +48,14 @@ impl PreparedDiagnosticSession {
     /// Execute one closed EA189 candidate probe while retaining this session.
     pub async fn read_dpf_probe(
         &self,
-        request: TargetedDpfProbeRequest,
+        probe: crate::ea189::Ea189DpfProbe,
+        mapping: &crate::vehicle_knowledge::EcuTargetMapping,
     ) -> Result<DiagnosticResponses, String> {
-        self.session.read_dpf_probe(request).await
+        self.session
+            .read_dpf_probe(crate::elm::TargetedDpfProbeRequest::from_mapping(
+                probe, mapping,
+            )?)
+            .await
     }
 
     /// Execute the one bounded stored-DTC request and deterministically close
@@ -329,7 +334,7 @@ impl SessionClient {
     /// Execute the closed EA189 DPF UDS probe and return its raw normalized
     /// responses.  Negative or malformed responses are returned as errors,
     /// while the crate-visible evidence variant retains responder payloads.
-    pub async fn read_dpf_probe(
+    pub(crate) async fn read_dpf_probe(
         &self,
         request: TargetedDpfProbeRequest,
     ) -> Result<DiagnosticResponses, String> {

--- a/src/elm.rs
+++ b/src/elm.rs
@@ -167,7 +167,7 @@ pub struct TargetedReadRequest {
 /// The closed EA189 DPF UDS probe.  The profile fixes the DID; callers can
 /// provide only independently validated physical routing evidence.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TargetedDpfProbeRequest {
+pub(crate) struct TargetedDpfProbeRequest {
     operation: crate::protocol::ReadOperation,
     target: RequestTarget,
     expected_responder: ResponderIdentity,
@@ -252,7 +252,7 @@ pub struct TargetedMode09Request {
 
 impl TargetedDpfProbeRequest {
     /// Construct a closed EA189 probe from validated engine target evidence.
-    pub fn from_mapping(
+    pub(crate) fn from_mapping(
         probe: crate::ea189::Ea189DpfProbe,
         mapping: &crate::vehicle_knowledge::EcuTargetMapping,
     ) -> Result<Self, String> {
@@ -292,10 +292,6 @@ impl TargetedDpfProbeRequest {
 
     pub fn did(&self) -> u16 {
         self.operation.did()
-    }
-
-    pub fn request_bytes(&self) -> [u8; 3] {
-        self.operation.request_bytes()
     }
 
     pub fn target(&self) -> &RequestTarget {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1682,8 +1682,7 @@ async fn run_diagnose_ea189_dpf_probe_inner(
                 }
                 Err(error) => return Err(error.to_string()),
             }
-            let request = ble::TargetedDpfProbeRequest::from_mapping(probe, &mapping)?;
-            match prepared.read_dpf_probe(request).await {
+            match prepared.read_dpf_probe(probe, &mapping).await {
                 Ok(responses) => {
                     let response = responses.as_slice().first().ok_or_else(|| {
                         format!("{} returned no normalized response", probe.semantic())


### PR DESCRIPTION
Closes #150\n\nKeeps the closed EA189 DPF request construction inside PreparedDiagnosticSession, removing the ELM-shaped request type from the public BLE interface and CLI orchestration.\n\nChecks: fmt, 46 BLE tests, clippy -D warnings, build. Full local test suite is blocked by a pre-existing detached knowledge submodule revision; no knowledge changes are included.