### PR TITLE
Make AGENTS.md harness-agnostic; add Claude Code equivalent

### DIFF
--- a/.claude/agents/worker.md
+++ b/.claude/agents/worker.md
@@ -1,0 +1,15 @@
+---
+name: worker
+description: General delegation target for bounded, non-trivial work in this repository — repository discovery, mechanical checks, focused searches, isolated implementation, tests, and isolated bug fixes. Use when the primary agent wants to delegate per AGENTS.md's Delegation section, with a concrete assignment and a non-overlapping write scope.
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+Follow `AGENTS.md` at the repository root for this project's workflow and constraints — read it first if you have not already.
+
+Work only within the scope you were given; do not touch files outside it, and do not revert work from other agents that may be running in parallel. Investigate existing code before changing it. Run the relevant checks for what you touched (see AGENTS.md's Project constraints) before reporting back.
+
+Report concisely at the end:
+- what changed
+- which files were affected
+- which checks were run
+- what remains open or uncertain

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # OBDentic agent instructions
 
+These instructions apply to any coding agent working in this repository, regardless of harness (Codex CLI, Claude Code, or otherwise). Harness-specific mechanics — which sub-agents exist and how to invoke them — live in that harness's own configuration; see "Harness-specific configuration" at the end of this file.
+
 ## Delegation
 
-Use sub-agents deliberately instead of implementing every non-trivial task in the primary agent. Use `gpt-5.6-luna` exclusively for sub-agents; do not delegate to `gpt-5.6-terra` or `gpt-5.6-sol`. Recreate this worker when useful at the start of a new session:
+Delegate bounded, non-trivial work to sub-agents instead of implementing everything in the primary agent. Give every sub-agent a concrete, bounded assignment and a non-overlapping write scope. Choose the lowest-cost sub-agent that can reliably handle the task. Parallelize independent work only; the primary agent owns integration and final verification. Do not delegate trivial work when coordination would cost more than doing it directly.
 
-- `luna_worker`: `gpt-5.6-luna`, `xhigh` reasoning — repository discovery, mechanical checks, focused searches, bounded implementation, tests and isolated bug fixes.
-
-Choose the lowest-cost worker that can reliably handle the task. Give every worker a concrete, bounded assignment and a non-overlapping write scope. Parallelize independent work only; the primary agent owns integration and final verification. Do not delegate trivial work when coordination would cost more than doing it directly.
+Good delegation targets: repository discovery, mechanical checks, focused searches, bounded implementation, tests, and isolated bug fixes.
 
 ## Issue workflow
 
@@ -37,3 +37,8 @@ Single-context layout: `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`
   `rtk env PATH=/Users/frankherchet/.cargo/bin:/opt/local/bin:/usr/bin:/bin cargo +1.98.0 ...`.
 - Before handoff, run the smallest relevant checks; for the current codebase this includes `cargo test`, `cargo clippy --all-targets -- -D warnings`, and Swift compilation when the BLE probe changes.
 - A meaningful feature or bug-fix task is complete only after its relevant checks pass, its intended changes are committed to a feature branch, its pull request is merged into `main`, and the merge is visible on `origin/main`.
+
+## Harness-specific configuration
+
+- **Codex CLI**: define named sub-agent/model profiles in your own `~/.codex/config.toml` (or `agents/*.toml`). This repository does not pin sub-agent names or models — use whatever profile your environment provides, and apply the Delegation principles above when choosing one.
+- **Claude Code**: sub-agents are defined in `.claude/agents/*.md`; `.claude/agents/worker.md` is the general delegation target for the tasks described above. `CLAUDE.md` at the repository root imports this file (`@AGENTS.md`), so these instructions apply automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- `AGENTS.md`'s Delegation section hardcoded personal Codex sub-agent model aliases (`gpt-5.6-luna`/`terra`/`sol`) that only exist in one user's global `~/.codex/config.toml` — fragile for other Codex users/machines and meaningless to any other harness. Replaced with harness-neutral delegation principles (bounded scope, non-overlapping writes, lowest-cost capable worker, parallelize independent work only), plus a new "Harness-specific configuration" section pointing each harness to where its own sub-agent config lives.
- Added `CLAUDE.md` (`@AGENTS.md` import) so Claude Code loads the same project workflow/constraints — Claude Code doesn't natively read `AGENTS.md`.
- Added `.claude/agents/worker.md`, a project-local subagent mirroring the old `luna_worker`'s intent (repository discovery, mechanical checks, focused searches, bounded implementation, tests, isolated bug fixes) without pinning a specific model.

Everything else in `AGENTS.md` (issue workflow, project constraints, read-only/DTC-clear invariants, evidence handling, `rtk` convention) was already harness-agnostic and is unchanged.

## Test plan

- [x] `git diff --stat` reviewed — only `AGENTS.md`, `CLAUDE.md`, `.claude/agents/worker.md` touched
- [x] Confirm a Claude Code session in this repo picks up `AGENTS.md` content via `CLAUDE.md`'s import
- [x] Confirm a Codex CLI session still reads root `AGENTS.md` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)