### PR TITLE
Orchestrate topology provider discovery evidence

### DIFF
--- a/docs/topology-providers.md
+++ b/docs/topology-providers.md
@@ -147,8 +147,14 @@ The provider domain and cache persistence contain no provider execution trait, a
 
 Future orchestration may execute a reviewed provider and then persist the resulting domain evidence, but transport remains below the typed diagnostic/safety boundary. The provider result itself is evidence only.
 
-## Discovery follow-up
+## Discovery orchestration
 
-With the provider domain and persistence seam established, the remaining #125 integration is discovery orchestration: applicable reviewed providers can later be composed with functional OBD discovery while preserving fallback and structured partial-coverage reporting.
+`vehicle discover` composes functional OBD discovery with the reviewed provider
+states, persists the result through the existing private v5 cache and reports
+structured coverage. The current EA189/PQ35 gateway provider is recorded as
+`blocked` with `unknown` coverage; it sends no gateway traffic and does not
+claim a complete vehicle inventory.
 
-That orchestration remains a separate slice. It must reuse the existing private cache and topology types, and it must not add live VW/PQ35 gateway traffic until new reviewed evidence resolves issue #35.
+Any future provider must continue to reuse the existing private cache and
+topology types. Live VW/PQ35 gateway traffic remains prohibited until new
+reviewed evidence resolves issue #35.

--- a/src/inventory_facts.rs
+++ b/src/inventory_facts.rs
@@ -381,6 +381,7 @@ mod tests {
         },
         vehicle_cache::TargetMappingSnapshot,
     };
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     fn context() -> ProtocolContext {
         ProtocolContext::new(Protocol::Obd2, AddressingContext::Physical)
@@ -395,14 +396,13 @@ mod tests {
     }
 
     const TEST_REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
+    static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(0);
 
     fn catalog(semantic: &str, id: &str, did: u16, decoder: &str) -> KnowledgeCatalog {
         let root = std::env::temp_dir().join(format!(
-            "obdentic-inventory-facts-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            "obdentic-inventory-facts-{}-{}",
+            std::process::id(),
+            NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed),
         ));
         let standards = root.join("standards");
         std::fs::create_dir_all(&standards).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -876,8 +876,13 @@ async fn run_vehicle_discover_inner(adapter_id: &str, refresh: bool) -> Result<(
         .as_ref()
         .map(VehicleCache::first_seen_ms)
         .unwrap_or(now);
-    let base_snapshot = obdentic::vehicle_cache::VehicleCacheSnapshot::from_discovery(
+    let provider_results = obdentic::topology_provider::reviewed_topology_provider_results();
+    let inventory = obdentic::topology_provider::merge_topology_provider_results(
         &discovery.topology(),
+        &provider_results,
+    );
+    let base_snapshot = obdentic::vehicle_cache::VehicleCacheSnapshot::from_discovery(
+        inventory.topology(),
         &discovery.capabilities(),
     );
     let snapshot = obdentic::vehicle_cache::VehicleCacheSnapshot::with_ecu_identification(
@@ -885,7 +890,8 @@ async fn run_vehicle_discover_inner(adapter_id: &str, refresh: bool) -> Result<(
         base_snapshot.ecu_capabilities().to_vec(),
         target_mappings,
         ecu_identification,
-    );
+    )
+    .with_topology_provider_results(provider_results);
     let engine_target_validated = snapshot.target_mappings().iter().any(|mapping| {
         mapping
             .role()
@@ -922,6 +928,10 @@ async fn run_vehicle_discover_inner(adapter_id: &str, refresh: bool) -> Result<(
         );
     }
     println!("evidence\t{}", discovery.observations().len());
+    print!(
+        "{}",
+        render_topology_inventory_coverage(inventory.coverage())
+    );
     if !engine_target_validated {
         println!("target\tengine.rpm\tunavailable");
     } else {
@@ -1956,6 +1966,37 @@ fn print_cached_vehicle_discovery(cache: &VehicleCache) {
         );
     }
     println!("evidence\t{}", signature.topology().len());
+    let inventory = obdentic::topology_provider::merge_topology_provider_results(
+        &obdentic::topology::EcuTopology::new(),
+        cache.snapshot().topology_provider_results(),
+    );
+    print!(
+        "{}",
+        render_topology_inventory_coverage(inventory.coverage())
+    );
+}
+
+fn render_topology_inventory_coverage(
+    coverage: &obdentic::topology_provider::TopologyInventoryCoverage,
+) -> String {
+    let mut output = format!(
+        "inventory_coverage\t{}\ntopology_providers\t{}\n",
+        coverage.class().as_str(),
+        coverage.providers().len()
+    );
+    for provider in coverage.providers() {
+        let scope = provider.applicability().scope();
+        output.push_str(&format!(
+            "topology_provider\t{}@{}\tstatus={}\tcoverage={}\tmanufacturer={}\tplatform={}\n",
+            provider.id().name(),
+            provider.id().version(),
+            provider.status().as_str(),
+            provider.coverage().as_str(),
+            scope.manufacturer_name().unwrap_or("-"),
+            scope.platform_name().unwrap_or("-"),
+        ));
+    }
+    output
 }
 
 fn run_vehicle_show() -> Result<(), String> {
@@ -3279,6 +3320,24 @@ mod tests {
         assert!(output.contains("signal\t7E9\tengine.rpm\tnot-advertised\n"));
         assert!(output.contains("signal\t7E9\tvehicle.speed\tadvertised\n"));
         assert!(!output.contains("7E0"));
+    }
+
+    #[test]
+    fn renders_blocked_provider_coverage_without_claiming_complete_inventory() {
+        let inventory = obdentic::topology_provider::merge_topology_provider_results(
+            &obdentic::topology::EcuTopology::new(),
+            &obdentic::topology_provider::reviewed_topology_provider_results(),
+        );
+        let output = render_topology_inventory_coverage(inventory.coverage());
+
+        assert!(
+            output.contains("inventory_coverage\tmanufacturer-provider-unavailable-or-blocked\n")
+        );
+        assert!(output.contains(
+            "topology_provider\tvw.pq35.gateway-installation-list@1\tstatus=blocked\tcoverage=unknown\tmanufacturer=Volkswagen\tplatform=PQ35 / EA189\n"
+        ));
+        assert!(!output.contains("complete vehicle"));
+        assert!(!output.contains("all ECUs"));
     }
 
     #[test]

--- a/src/topology_provider.rs
+++ b/src/topology_provider.rs
@@ -163,12 +163,61 @@ pub enum TopologyProviderStatus {
     Failed,
 }
 
+impl TopologyProviderStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Unavailable => "unavailable",
+            Self::Blocked => "blocked",
+            Self::NotApplicable => "not-applicable",
+            Self::Failed => "failed",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub enum TopologyProviderCoverage {
     Unknown,
     Partial,
     Complete,
     NotApplicable,
+}
+
+impl TopologyProviderCoverage {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Partial => "partial",
+            Self::Complete => "complete",
+            Self::NotApplicable => "not-applicable",
+        }
+    }
+}
+
+/// Reviewed provider states available in this build.
+///
+/// The EA189/PQ35 gateway source is explicitly blocked by the evidence review.
+/// Returning its state records that limit without issuing any gateway request.
+pub fn reviewed_topology_provider_results() -> Vec<TopologyProviderResult> {
+    vec![TopologyProviderResult::new(
+        TopologyProviderId::new("vw.pq35.gateway-installation-list", 1)
+            .expect("static provider id is valid"),
+        TopologyProviderApplicability::new(
+            TopologyProviderScope::platform("Volkswagen", "PQ35 / EA189")
+                .expect("static provider scope is valid"),
+            Provenance::new(
+                "docs/research/vw-gateway-installation-list.md",
+                crate::topology::Confidence::High,
+            )
+            .expect("static provider provenance is valid"),
+        ),
+        TopologyProviderStatus::Blocked,
+        TopologyProviderCoverage::Unknown,
+        [],
+        [EvidenceReference::new("issue #35 negative safety gate")
+            .expect("static provider evidence is valid")],
+    )
+    .expect("static blocked provider result is valid")]
 }
 
 /// One configured/installed-controller fact produced by a topology provider.
@@ -342,6 +391,18 @@ pub enum TopologyInventoryCoverageClass {
     FunctionalObdOnly,
     TopologyProviderEvidenceAvailable,
     TopologyProviderUnavailableOrBlocked,
+}
+
+impl TopologyInventoryCoverageClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::FunctionalObdOnly => "functional-obd-only",
+            Self::TopologyProviderEvidenceAvailable => "manufacturer-provider-evidence-available",
+            Self::TopologyProviderUnavailableOrBlocked => {
+                "manufacturer-provider-unavailable-or-blocked"
+            }
+        }
+    }
 }
 
 /// Coverage remains structured so separate provider scopes are never collapsed
@@ -780,5 +841,16 @@ mod tests {
             inventory.coverage().providers()[0].id().name(),
             "vw.pq35.gateway-installation-list"
         );
+    }
+
+    #[test]
+    fn reviewed_provider_selection_is_deterministic_and_blocked() {
+        let results = reviewed_topology_provider_results();
+        assert_eq!(results, reviewed_topology_provider_results());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id().name(), "vw.pq35.gateway-installation-list");
+        assert_eq!(results[0].status(), TopologyProviderStatus::Blocked);
+        assert_eq!(results[0].coverage(), TopologyProviderCoverage::Unknown);
+        assert!(results[0].entries().is_empty());
     }
 }


### PR DESCRIPTION
Closes #125

Composes functional OBD discovery with the reviewed topology-provider state, persists that state through the existing private cache v5 path, and reports structured coverage in live and cached `vehicle discover` output.

The PQ35/EA189 gateway source is recorded only as blocked evidence. This PR adds no vehicle, gateway, CAN, UDS, session-control, or other transport request.

Validation: `cargo test topology_provider --lib`, `cargo test --bin obdentic`, `cargo clippy --all-targets -- -D warnings`, `cargo build`. The complete local suite remains blocked by the pre-existing local `knowledge` submodule revision; it is not included in this PR.