### PR TITLE
Record knowledge provenance in captures

### DIFF
--- a/docs/knowledge-db.md
+++ b/docs/knowledge-db.md
@@ -35,7 +35,7 @@ The canonical repository is checked in as the `knowledge/` Git submodule. `knowl
 ```text
 repository = frankherchet/obdentic-knowledge
 revision = <40-character commit SHA>
-schema_version = 1
+schema_version = 2
 ```
 
 The Git submodule is the source pin. `knowledge.lock` exists so runtime/capture code can expose deterministic Knowledge provenance without shelling out to Git.
@@ -76,7 +76,7 @@ CI verifies that the initialized submodule HEAD matches `knowledge.lock`.
 `knowledge_db::KnowledgeCatalog` is transport-free. It:
 
 - reads only local files;
-- accepts schema version 1 only;
+- accepts schema version 2 only;
 - enumerates canonical YAML files deterministically;
 - rejects symlinked canonical entries;
 - uses strict `serde(deny_unknown_fields)` input structs;
@@ -94,4 +94,19 @@ The schema already reserves an `obd2.mode01.pid` descriptor for staged migration
 
 ## Capture provenance
 
-Issue #89 will persist the active Knowledge repository revision/schema and resolved definition identities in captures. This #84 loader exposes the information needed for that later step but does not change the capture schema itself.
+New JSONL captures record a session-level Knowledge context: OBDentic core
+version, optional build commit, canonical repository, exact pinned revision and
+schema version. A capture may additionally record the selected canonical
+definition ID/version, confidence, hardware-validation status and a
+privacy-safe local ECU context for an individual decoded fact.
+
+Current generic Mode-01 signals are still implemented by the closed built-in
+catalog, rather than canonical Knowledge definitions. Their definition fields
+are therefore explicitly absent; OBDentic never invents a canonical definition
+ID. When a later effective-Knowledge profile resolves a definition, it can fill
+the same fields.
+
+Old captures without a Knowledge context remain readable and are reported as
+`legacy/unavailable`. Replay preserves their original recorded interpretation
+separately from a current deterministic re-decode. It neither fetches Knowledge
+from the network nor rewrites recorded raw evidence or old capture files.

--- a/src/capture_events.rs
+++ b/src/capture_events.rs
@@ -74,6 +74,176 @@ pub struct CaptureSubscription {
     filter: SubscriptionFilterOutcome,
 }
 
+pub const MAX_CAPTURE_CORE_VERSION_LEN: usize = 64;
+pub const MAX_CAPTURE_COMMIT_LEN: usize = 40;
+pub const MAX_CAPTURE_KNOWLEDGE_REPOSITORY_LEN: usize = 128;
+pub const MAX_CAPTURE_KNOWLEDGE_REVISION_LEN: usize = 40;
+pub const MAX_CAPTURE_DEFINITION_ID_LEN: usize = 128;
+pub const MAX_CAPTURE_CONFIDENCE_LEN: usize = 32;
+pub const MAX_CAPTURE_HARDWARE_VALIDATION_LEN: usize = 64;
+pub const MAX_CAPTURE_LOCAL_ECU_ID_LEN: usize = 64;
+
+/// The exact executable and canonical Knowledge inputs used by a capture.
+///
+/// This contains repository metadata only. It deliberately contains no VIN,
+/// ECU serial number, responder payload or other vehicle-instance identity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CaptureKnowledgeContext {
+    core_version: String,
+    core_commit: Option<String>,
+    knowledge_repository: String,
+    knowledge_revision: String,
+    knowledge_schema_version: u32,
+}
+
+impl CaptureKnowledgeContext {
+    /// Loads the compile-time project pin without shelling out to Git or
+    /// reading vehicle-specific inventory data.
+    pub fn current() -> Result<Self, String> {
+        let pin = crate::knowledge_db::KnowledgePin::load(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("knowledge.lock"),
+        )
+        .map_err(|error| format!("capture knowledge pin unavailable: {error}"))?;
+        Self::new(
+            env!("CARGO_PKG_VERSION"),
+            None,
+            pin.repository(),
+            pin.revision(),
+            pin.schema_version(),
+        )
+    }
+
+    pub fn new(
+        core_version: impl Into<String>,
+        core_commit: Option<String>,
+        knowledge_repository: impl Into<String>,
+        knowledge_revision: impl Into<String>,
+        knowledge_schema_version: u32,
+    ) -> Result<Self, String> {
+        let core_version = core_version.into();
+        let knowledge_repository = knowledge_repository.into();
+        let knowledge_revision = knowledge_revision.into();
+        validate_capture_text("core version", &core_version, MAX_CAPTURE_CORE_VERSION_LEN)?;
+        validate_capture_commit(core_commit.as_deref(), "core commit")?;
+        validate_capture_text(
+            "knowledge repository",
+            &knowledge_repository,
+            MAX_CAPTURE_KNOWLEDGE_REPOSITORY_LEN,
+        )?;
+        validate_capture_revision(&knowledge_revision, "knowledge revision")?;
+        if knowledge_schema_version == 0 {
+            return Err("knowledge schema version must be positive".into());
+        }
+        Ok(Self {
+            core_version,
+            core_commit,
+            knowledge_repository,
+            knowledge_revision,
+            knowledge_schema_version,
+        })
+    }
+
+    pub fn core_version(&self) -> &str {
+        &self.core_version
+    }
+
+    pub fn core_commit(&self) -> Option<&str> {
+        self.core_commit.as_deref()
+    }
+
+    pub fn knowledge_repository(&self) -> &str {
+        &self.knowledge_repository
+    }
+
+    pub fn knowledge_revision(&self) -> &str {
+        &self.knowledge_revision
+    }
+
+    pub const fn knowledge_schema_version(&self) -> u32 {
+        self.knowledge_schema_version
+    }
+}
+
+/// A privacy-safe reference to the Knowledge definition used for one fact.
+///
+/// `local_ecu_id` is an application-owned local identifier, not a VIN or ECU
+/// serial number. Callers must not place vehicle identity values in it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CaptureDefinitionReference {
+    definition_id: Option<String>,
+    definition_version: Option<u32>,
+    confidence: Option<String>,
+    hardware_validation: Option<String>,
+    local_ecu_id: Option<String>,
+}
+
+impl CaptureDefinitionReference {
+    pub fn new(
+        definition_id: Option<String>,
+        definition_version: Option<u32>,
+        confidence: Option<String>,
+        hardware_validation: Option<String>,
+        local_ecu_id: Option<String>,
+    ) -> Result<Self, String> {
+        if definition_id.is_some() != definition_version.is_some() {
+            return Err("definition id and version must be provided together".into());
+        }
+        if definition_id.is_none() {
+            return Err("definition reference requires an id and version".into());
+        }
+        if definition_version == Some(0) {
+            return Err("definition version must be positive".into());
+        }
+        validate_capture_optional_text(
+            "definition id",
+            definition_id.as_deref(),
+            MAX_CAPTURE_DEFINITION_ID_LEN,
+        )?;
+        validate_capture_optional_text(
+            "confidence",
+            confidence.as_deref(),
+            MAX_CAPTURE_CONFIDENCE_LEN,
+        )?;
+        validate_capture_optional_text(
+            "hardware validation",
+            hardware_validation.as_deref(),
+            MAX_CAPTURE_HARDWARE_VALIDATION_LEN,
+        )?;
+        validate_capture_optional_text(
+            "local ECU id",
+            local_ecu_id.as_deref(),
+            MAX_CAPTURE_LOCAL_ECU_ID_LEN,
+        )?;
+        Ok(Self {
+            definition_id,
+            definition_version,
+            confidence,
+            hardware_validation,
+            local_ecu_id,
+        })
+    }
+
+    pub fn definition_id(&self) -> Option<&str> {
+        self.definition_id.as_deref()
+    }
+
+    pub const fn definition_version(&self) -> Option<u32> {
+        self.definition_version
+    }
+
+    pub fn confidence(&self) -> Option<&str> {
+        self.confidence.as_deref()
+    }
+
+    pub fn hardware_validation(&self) -> Option<&str> {
+        self.hardware_validation.as_deref()
+    }
+
+    pub fn local_ecu_id(&self) -> Option<&str> {
+        self.local_ecu_id.as_deref()
+    }
+}
+
 impl CaptureSubscription {
     pub fn new(
         semantic: impl Into<String>,
@@ -178,6 +348,9 @@ pub enum CaptureEvent {
         wallclock_ms: Option<u64>,
         profile: Option<String>,
     },
+    KnowledgeContext {
+        context: CaptureKnowledgeContext,
+    },
     SessionInitialized,
     SubscriptionConfigured {
         semantic: String,
@@ -222,6 +395,7 @@ pub enum CaptureEvent {
         profile: String,
         decoder: String,
         provenance: String,
+        definition: Option<Box<CaptureDefinitionReference>>,
     },
     ReadFailed {
         semantic: String,
@@ -299,6 +473,10 @@ impl CaptureEvent {
             wallclock_ms,
             profile,
         }
+    }
+
+    pub fn knowledge_context(context: CaptureKnowledgeContext) -> Self {
+        Self::KnowledgeContext { context }
     }
 
     pub fn subscription_configured(
@@ -423,6 +601,23 @@ impl CaptureEvent {
         requested_interval_us: CaptureTimeUs,
         timing: ReadTiming,
     ) -> Result<Self, String> {
+        Self::read_succeeded_from_transaction_with_definition(
+            transaction,
+            requested_interval_us,
+            timing,
+            None,
+        )
+    }
+
+    /// Copy a completed read and attach an already validated Knowledge
+    /// definition reference. `None` is intentional for signals that are still
+    /// backed by the legacy built-in catalog rather than canonical Knowledge.
+    pub fn read_succeeded_from_transaction_with_definition(
+        transaction: &Transaction,
+        requested_interval_us: CaptureTimeUs,
+        timing: ReadTiming,
+        definition: Option<CaptureDefinitionReference>,
+    ) -> Result<Self, String> {
         let metadata = crate::supported_signals()
             .iter()
             .find(|signal| signal.metadata().semantic == transaction.semantic())
@@ -443,6 +638,7 @@ impl CaptureEvent {
             profile: transaction.profile().into(),
             decoder: metadata.decoder.into(),
             provenance: metadata.provenance.into(),
+            definition: definition.map(Box::new),
         })
     }
 
@@ -725,6 +921,47 @@ pub(crate) fn validate_diagnostic_text(
     Ok(())
 }
 
+fn validate_capture_text(label: &str, value: &str, max_len: usize) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("capture {label} must not be empty"));
+    }
+    if value.len() > max_len {
+        return Err(format!("capture {label} exceeds {max_len} bytes"));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(format!(
+            "capture {label} must not contain control characters"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_capture_optional_text(
+    label: &str,
+    value: Option<&str>,
+    max_len: usize,
+) -> Result<(), String> {
+    value.map_or(Ok(()), |value| validate_capture_text(label, value, max_len))
+}
+
+fn validate_capture_commit(value: Option<&str>, label: &str) -> Result<(), String> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    validate_capture_text(label, value, MAX_CAPTURE_COMMIT_LEN)?;
+    if value.len() != MAX_CAPTURE_COMMIT_LEN || !value.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(format!(
+            "capture {label} must be a 40-character hexadecimal Git commit"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_capture_revision(value: &str, label: &str) -> Result<(), String> {
+    validate_capture_commit(Some(value), label)
+}
+
 pub(crate) fn validate_diagnostic_mode(mode: u8) -> Result<(), String> {
     (1..=MAX_DIAGNOSTIC_MODE)
         .contains(&mode)
@@ -811,8 +1048,119 @@ mod tests {
                 profile: "obd2-v1".into(),
                 decoder: "((A * 256) + B) / 4".into(),
                 provenance: "SAE J1979 Mode 01 PID 0C".into(),
+                definition: None,
             }
         );
+    }
+
+    #[test]
+    fn knowledge_context_validates_and_preserves_exact_pin() {
+        let context = CaptureKnowledgeContext::new(
+            "0.1.0",
+            Some("0123456789abcdef0123456789abcdef01234567".into()),
+            "frankherchet/obdentic-knowledge",
+            "fedcba9876543210fedcba9876543210fedcba98",
+            2,
+        )
+        .unwrap();
+        assert_eq!(context.core_version(), "0.1.0");
+        assert_eq!(
+            context.core_commit(),
+            Some("0123456789abcdef0123456789abcdef01234567")
+        );
+        assert_eq!(
+            context.knowledge_repository(),
+            "frankherchet/obdentic-knowledge"
+        );
+        assert_eq!(
+            context.knowledge_revision(),
+            "fedcba9876543210fedcba9876543210fedcba98"
+        );
+        assert_eq!(context.knowledge_schema_version(), 2);
+        assert!(CaptureKnowledgeContext::new(
+            "0.1.0",
+            None,
+            "repo\nleak",
+            "fedcba9876543210fedcba9876543210fedcba98",
+            2,
+        )
+        .is_err());
+        assert!(CaptureKnowledgeContext::new("0.1.0", None, "repo", "not-a-revision", 2,).is_err());
+    }
+
+    #[test]
+    fn definition_reference_requires_a_paired_identity_and_keeps_local_context_private() {
+        assert!(CaptureDefinitionReference::new(
+            Some("knowledge.signal".into()),
+            None,
+            Some("high".into()),
+            Some("validated".into()),
+            Some("ecu-local-7e8".into()),
+        )
+        .is_err());
+        assert!(
+            CaptureDefinitionReference::new(None, None, Some("high".into()), None, None,).is_err()
+        );
+
+        let reference = CaptureDefinitionReference::new(
+            Some("uds.f189.manufacturer_software_version".into()),
+            Some(1),
+            Some("high".into()),
+            Some("validated".into()),
+            Some("ecu-local-7e8".into()),
+        )
+        .unwrap();
+        assert_eq!(
+            reference.definition_id(),
+            Some("uds.f189.manufacturer_software_version")
+        );
+        assert_eq!(reference.definition_version(), Some(1));
+        assert_eq!(reference.confidence(), Some("high"));
+        assert_eq!(reference.hardware_validation(), Some("validated"));
+        assert_eq!(reference.local_ecu_id(), Some("ecu-local-7e8"));
+    }
+
+    #[test]
+    fn read_constructor_keeps_legacy_builtin_signal_without_definition_reference() {
+        let transaction = prepare_read("engine.rpm")
+            .unwrap()
+            .complete("user", vec![0x41, 0x0c, 0x00, 0x00])
+            .unwrap();
+        let definition = CaptureDefinitionReference::new(
+            Some("obd2.engine.rpm".into()),
+            Some(1),
+            Some("high".into()),
+            Some("validated".into()),
+            Some("local-engine".into()),
+        )
+        .unwrap();
+        let event = CaptureEvent::read_succeeded_from_transaction_with_definition(
+            &transaction,
+            250_000,
+            ReadTiming::new(1, 2, 3),
+            Some(definition.clone()),
+        )
+        .unwrap();
+        assert!(matches!(
+            event,
+            CaptureEvent::ReadSucceeded {
+                definition: Some(reference),
+                ..
+            } if *reference == definition
+        ));
+        let legacy = CaptureEvent::read_succeeded_from_transaction(
+            &transaction,
+            250_000,
+            ReadTiming::new(1, 2, 3),
+        )
+        .unwrap();
+        assert!(matches!(
+            legacy,
+            CaptureEvent::ReadSucceeded {
+                definition: None,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/src/capture_replay.rs
+++ b/src/capture_replay.rs
@@ -6,9 +6,13 @@
 //! differences are reported as issues rather than rewritten.
 
 use crate::{
-    capture_events::{CaptureEvent, CaptureValue, ResponderEvidence},
+    capture_events::{
+        CaptureDefinitionReference, CaptureEvent, CaptureKnowledgeContext, CaptureValue,
+        ResponderEvidence,
+    },
     ea189::{decode_experimental_dpf, Ea189DpfProbe, Ea189ExperimentalDpfReading},
     jsonl_capture::ParsedCapture,
+    knowledge_db::KnowledgePin,
     prepare_read,
     telemetry::TelemetryState,
     Transaction,
@@ -77,10 +81,55 @@ impl DpfReplayReading {
     }
 }
 
+/// The interpretation recorded at capture time, preserved separately from a
+/// later replay decode of the same raw response.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecordedReadInterpretation {
+    at_us: u64,
+    semantic: String,
+    value: CaptureValue,
+    unit: String,
+    decoder: String,
+    provenance: String,
+    definition: Option<CaptureDefinitionReference>,
+}
+
+impl RecordedReadInterpretation {
+    pub const fn at_us(&self) -> u64 {
+        self.at_us
+    }
+
+    pub fn semantic(&self) -> &str {
+        &self.semantic
+    }
+
+    pub fn value(&self) -> &CaptureValue {
+        &self.value
+    }
+
+    pub fn unit(&self) -> &str {
+        &self.unit
+    }
+
+    pub fn decoder(&self) -> &str {
+        &self.decoder
+    }
+
+    pub fn provenance(&self) -> &str {
+        &self.provenance
+    }
+
+    pub fn definition(&self) -> Option<&CaptureDefinitionReference> {
+        self.definition.as_ref()
+    }
+}
+
 pub struct CaptureReplay {
     duration_us: u64,
+    knowledge_context: Option<CaptureKnowledgeContext>,
     offsets_us: Vec<u64>,
     transactions: Vec<Transaction>,
+    recorded_interpretations: Vec<RecordedReadInterpretation>,
     dpf_readings: Vec<DpfReplayReading>,
     issues: Vec<ReplayIssue>,
 }
@@ -93,7 +142,12 @@ impl CaptureReplay {
     /// not make the rest of the capture unusable.
     pub fn from_capture(capture: &ParsedCapture) -> Self {
         let mut duration_us = 0_u64;
+        let knowledge_context = capture.events.iter().find_map(|event| match event {
+            CaptureEvent::KnowledgeContext { context } => Some(context.clone()),
+            _ => None,
+        });
         let mut decoded = Vec::<(u64, Transaction)>::new();
+        let mut recorded_interpretations = Vec::new();
         let mut dpf_readings = Vec::new();
         let mut issues = Vec::new();
 
@@ -107,9 +161,21 @@ impl CaptureReplay {
                     value,
                     unit,
                     source,
+                    decoder,
+                    provenance,
+                    definition,
                     ..
                 } => {
                     duration_us = duration_us.max(*finished_us);
+                    recorded_interpretations.push(RecordedReadInterpretation {
+                        at_us: *finished_us,
+                        semantic: semantic.clone(),
+                        value: value.clone(),
+                        unit: unit.clone(),
+                        decoder: decoder.clone(),
+                        provenance: provenance.clone(),
+                        definition: definition.as_deref().cloned(),
+                    });
                     let request = match prepare_read(semantic) {
                         Ok(request) => request,
                         Err(error) => {
@@ -213,8 +279,10 @@ impl CaptureReplay {
         issues.sort_by_key(ReplayIssue::at_us);
         Self {
             duration_us,
+            knowledge_context,
             offsets_us,
             transactions,
+            recorded_interpretations,
             dpf_readings,
             issues,
         }
@@ -224,6 +292,22 @@ impl CaptureReplay {
         self.duration_us
     }
 
+    /// The exact Knowledge pin recorded by a new capture, or `None` for a
+    /// legacy capture that predates provenance events.
+    pub fn knowledge_context(&self) -> Option<&CaptureKnowledgeContext> {
+        self.knowledge_context.as_ref()
+    }
+
+    /// Compares only recorded pin identity; it never fetches or rewrites
+    /// Knowledge during offline replay.
+    pub fn matches_knowledge_pin(&self, pin: &KnowledgePin) -> Option<bool> {
+        self.knowledge_context().map(|context| {
+            context.knowledge_repository() == pin.repository()
+                && context.knowledge_revision() == pin.revision()
+                && context.knowledge_schema_version() == pin.schema_version()
+        })
+    }
+
     /// Exact monotonic JSONL timestamps aligned one-to-one with [`Self::transactions`].
     pub fn offsets_us(&self) -> &[u64] {
         &self.offsets_us
@@ -231,6 +315,10 @@ impl CaptureReplay {
 
     pub fn transactions(&self) -> &[Transaction] {
         &self.transactions
+    }
+
+    pub fn recorded_interpretations(&self) -> &[RecordedReadInterpretation] {
+        &self.recorded_interpretations
     }
 
     /// Successful Gate-B DPF decodes. These remain outside [`TelemetryState`]
@@ -440,8 +528,11 @@ fn capture_value_text(value: &CaptureValue) -> String {
 mod tests {
     use super::*;
     use crate::{
-        capture_events::{ReadTiming, ResponderEvidence},
+        capture_events::{
+            CaptureDefinitionReference, CaptureKnowledgeContext, ReadTiming, ResponderEvidence,
+        },
         jsonl_capture::CaptureStatus,
+        knowledge_db::KnowledgePin,
     };
 
     fn successful_read(
@@ -466,6 +557,7 @@ mod tests {
             profile: "obd2-v1".into(),
             decoder: "recorded-decoder".into(),
             provenance: "recorded-provenance".into(),
+            definition: None,
         }
     }
 
@@ -516,15 +608,37 @@ mod tests {
 
     #[test]
     fn raw_response_is_redecoded_instead_of_trusting_recorded_value() {
+        let context = CaptureKnowledgeContext::new(
+            "0.1.0",
+            None,
+            "frankherchet/obdentic-knowledge",
+            "0123456789abcdef0123456789abcdef01234567",
+            2,
+        )
+        .unwrap();
+        let mut recorded = successful_read(
+            "engine.rpm",
+            1_234_567,
+            vec![0x01, 0x0c],
+            vec![0x41, 0x0c, 0x0c, 0x80],
+            9_999.0,
+            "rpm",
+        );
+        if let CaptureEvent::ReadSucceeded { definition, .. } = &mut recorded {
+            *definition = Some(Box::new(
+                CaptureDefinitionReference::new(
+                    Some("obd2.engine.rpm".into()),
+                    Some(1),
+                    Some("high".into()),
+                    Some("validated".into()),
+                    Some("local-engine".into()),
+                )
+                .unwrap(),
+            ));
+        }
         let replay = CaptureReplay::from_capture(&capture(vec![
-            successful_read(
-                "engine.rpm",
-                1_234_567,
-                vec![0x01, 0x0c],
-                vec![0x41, 0x0c, 0x0c, 0x80],
-                9_999.0,
-                "rpm",
-            ),
+            CaptureEvent::knowledge_context(context.clone()),
+            recorded,
             CaptureEvent::SessionStopped {
                 offset_us: 2_000_000,
             },
@@ -540,6 +654,31 @@ mod tests {
             replay.issues()[0].kind(),
             ReplayIssueKind::RecordedDecodeChanged
         );
+        assert_eq!(replay.recorded_interpretations().len(), 1);
+        assert_eq!(
+            replay.recorded_interpretations()[0].value(),
+            &CaptureValue::Number(9_999.0)
+        );
+        assert_eq!(
+            replay.recorded_interpretations()[0]
+                .definition()
+                .and_then(CaptureDefinitionReference::definition_id),
+            Some("obd2.engine.rpm")
+        );
+        let matching_pin = KnowledgePin::new(
+            context.knowledge_repository(),
+            context.knowledge_revision(),
+            context.knowledge_schema_version(),
+        )
+        .unwrap();
+        assert_eq!(replay.matches_knowledge_pin(&matching_pin), Some(true));
+        let different_pin = KnowledgePin::new(
+            "frankherchet/obdentic-knowledge",
+            "fedcba9876543210fedcba9876543210fedcba98",
+            2,
+        )
+        .unwrap();
+        assert_eq!(replay.matches_knowledge_pin(&different_pin), Some(false));
     }
 
     #[test]

--- a/src/capture_report.rs
+++ b/src/capture_report.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     capture_events::{
-        CaptureEvent, CaptureTimeUs, CaptureValue, DiagnosticJobStepStatus, DtcObservationFact,
-        DtcTransportOutcome, SubscriptionFilterOutcome,
+        CaptureEvent, CaptureKnowledgeContext, CaptureTimeUs, CaptureValue,
+        DiagnosticJobStepStatus, DtcObservationFact, DtcTransportOutcome,
+        SubscriptionFilterOutcome,
     },
     jsonl_capture::{CaptureStatus, ParsedCapture},
 };
@@ -37,6 +38,7 @@ struct Summary {
     session_stopped_us: Option<CaptureTimeUs>,
     profile: Option<String>,
     wallclock_ms: Option<u64>,
+    knowledge_context: Option<CaptureKnowledgeContext>,
     session_errors: Vec<String>,
     error_messages: BTreeMap<String, u64>,
     all_reads: Vec<(CaptureTimeUs, CaptureTimeUs, CaptureTimeUs)>,
@@ -65,6 +67,10 @@ fn summary(capture: &ParsedCapture) -> Summary {
                 summary.lifecycle += 1;
                 summary.wallclock_ms = *wallclock_ms;
                 summary.profile = profile.clone();
+            }
+            CaptureEvent::KnowledgeContext { context } => {
+                summary.lifecycle += 1;
+                summary.knowledge_context = Some(context.clone());
             }
             CaptureEvent::SessionInitialized
             | CaptureEvent::SupportDiscovery { .. }
@@ -233,10 +239,11 @@ fn observe_offset(summary: &mut Summary, offset: CaptureTimeUs) {
 pub fn render_inspection(path: &str, capture: &ParsedCapture) -> String {
     let summary = summary(capture);
     let mut output = format!(
-        "Capture: {path}\nFormat: JSONL {}\nStatus: {}\nProfile: {}\nStarted: {}\nDuration: {}\nEvents: {}\nReads: {} succeeded, {} failed\nSkipped: {} events, {} slots\nDiagnostic jobs: {} started, {} completed, {} failed, {} cancelled\nDiagnostic steps: {} success, {} recoverable, {} fatal, {} skipped\nDTC transport observations: {}\nDTC decoded observations: {}\nLifecycle events: {}\n\nSignals\n",
+        "Capture: {path}\nFormat: JSONL {}\nStatus: {}\nProfile: {}\nKnowledge: {}\nStarted: {}\nDuration: {}\nEvents: {}\nReads: {} succeeded, {} failed\nSkipped: {} events, {} slots\nDiagnostic jobs: {} started, {} completed, {} failed, {} cancelled\nDiagnostic steps: {} success, {} recoverable, {} fatal, {} skipped\nDTC transport observations: {}\nDTC decoded observations: {}\nLifecycle events: {}\n\nSignals\n",
         crate::jsonl_capture::VERSION,
         status(capture.status),
         summary.profile.as_deref().unwrap_or("unavailable"),
+        knowledge_context(summary.knowledge_context.as_ref()),
         summary.wallclock_ms.map_or_else(|| "unavailable".into(), |value| value.to_string()),
         duration(&summary),
         summary.events,
@@ -303,6 +310,19 @@ pub fn render_inspection(path: &str, capture: &ParsedCapture) -> String {
         }
     }
     output
+}
+
+fn knowledge_context(context: Option<&CaptureKnowledgeContext>) -> String {
+    let Some(context) = context else {
+        return "legacy/unavailable".into();
+    };
+    format!(
+        "{}@{} schema {} (core {})",
+        context.knowledge_repository(),
+        context.knowledge_revision(),
+        context.knowledge_schema_version(),
+        context.core_version(),
+    )
 }
 
 pub fn render_capability(path: &str, capture: &ParsedCapture) -> String {
@@ -511,7 +531,9 @@ fn percentage(part: u64, total: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::capture_events::{CaptureEvent, CaptureValue, DiagnosticJobStepStatus};
+    use crate::capture_events::{
+        CaptureEvent, CaptureKnowledgeContext, CaptureValue, DiagnosticJobStepStatus,
+    };
     use crate::diagnostic_job::JobStatus;
 
     fn capture(events: Vec<CaptureEvent>) -> ParsedCapture {
@@ -543,6 +565,7 @@ mod tests {
             profile: "generic-obd2".into(),
             decoder: "x".into(),
             provenance: "x".into(),
+            definition: None,
         }
     }
 
@@ -572,6 +595,28 @@ mod tests {
         assert!(rendered.contains("Reads: 2 succeeded, 1 failed"));
         assert!(rendered.contains("numeric range: 800 .. 900"));
         assert!(rendered.contains("ambiguous responders"));
+        assert!(rendered.contains("Knowledge: legacy/unavailable"));
+    }
+
+    #[test]
+    fn inspection_renders_recorded_knowledge_pin_without_vehicle_identity() {
+        let rendered = render_inspection(
+            "sample.jsonl",
+            &capture(vec![CaptureEvent::knowledge_context(
+                CaptureKnowledgeContext::new(
+                    "0.1.0",
+                    None,
+                    "frankherchet/obdentic-knowledge",
+                    "0123456789abcdef0123456789abcdef01234567",
+                    2,
+                )
+                .unwrap(),
+            )]),
+        );
+        assert!(rendered.contains(
+            "Knowledge: frankherchet/obdentic-knowledge@0123456789abcdef0123456789abcdef01234567 schema 2 (core 0.1.0)"
+        ));
+        assert!(!rendered.contains("VIN"));
     }
 
     #[test]

--- a/src/capture_tui.rs
+++ b/src/capture_tui.rs
@@ -93,6 +93,7 @@ impl Timeline {
                         ),
                     );
                 }
+                CaptureEvent::KnowledgeContext { .. } => {}
                 CaptureEvent::SessionInitialized => {
                     timeline.push(clock_us, "session", None, "initialized".into());
                 }
@@ -969,6 +970,7 @@ mod tests {
             profile: "obd2-v1".into(),
             decoder: "test".into(),
             provenance: "synthetic".into(),
+            definition: None,
         }
     }
 

--- a/src/jsonl_capture.rs
+++ b/src/jsonl_capture.rs
@@ -1,8 +1,9 @@
 use crate::{
     capture_events::{
         validate_diagnostic_error, validate_diagnostic_job_id, validate_diagnostic_mode,
-        validate_diagnostic_source, validate_diagnostic_text, validate_dtc_fact, CaptureEvent,
-        CaptureValue, DiagnosticJobStepStatus, DtcObservationFact, DtcTransportOutcome, ReadTiming,
+        validate_diagnostic_source, validate_diagnostic_text, validate_dtc_fact,
+        CaptureDefinitionReference, CaptureEvent, CaptureKnowledgeContext, CaptureValue,
+        DiagnosticJobStepStatus, DtcObservationFact, DtcTransportOutcome, ReadTiming,
         SubscriptionFilterOutcome, MAX_DTC_DECODER_LEN, MAX_DTC_PROVENANCE_LEN,
     },
     diagnostic_job::JobStatus,
@@ -147,6 +148,20 @@ fn event_line(sequence: u64, event: &CaptureEvent) -> Result<String, String> {
             object.push_str(",\"profile\":");
             push_option_string(&mut object, profile.as_deref());
         }
+        CaptureEvent::KnowledgeContext { context } => {
+            object.push_str("\"knowledge_context\",\"sequence\":");
+            object.push_str(&sequence.to_string());
+            object.push_str(",\"core_version\":");
+            push_string(&mut object, context.core_version());
+            object.push_str(",\"core_commit\":");
+            push_option_string(&mut object, context.core_commit());
+            object.push_str(",\"knowledge_repository\":");
+            push_string(&mut object, context.knowledge_repository());
+            object.push_str(",\"knowledge_revision\":");
+            push_string(&mut object, context.knowledge_revision());
+            object.push_str(",\"knowledge_schema_version\":");
+            object.push_str(&context.knowledge_schema_version().to_string());
+        }
         CaptureEvent::SessionInitialized => {
             simple_event(&mut object, "session_initialized", sequence)
         }
@@ -238,6 +253,7 @@ fn event_line(sequence: u64, event: &CaptureEvent) -> Result<String, String> {
             profile,
             decoder,
             provenance,
+            definition,
         } => {
             object.push_str("\"read_succeeded\",\"sequence\":");
             object.push_str(&sequence.to_string());
@@ -267,6 +283,7 @@ fn event_line(sequence: u64, event: &CaptureEvent) -> Result<String, String> {
             push_string(&mut object, decoder);
             object.push_str(",\"provenance\":");
             push_string(&mut object, provenance);
+            push_definition_reference(&mut object, definition.as_deref());
         }
         CaptureEvent::ReadFailed {
             semantic,
@@ -580,6 +597,34 @@ fn push_option_string(object: &mut String, value: Option<&str>) {
     }
 }
 
+fn push_definition_reference(object: &mut String, definition: Option<&CaptureDefinitionReference>) {
+    object.push_str(",\"knowledge_definition_id\":");
+    push_option_string(
+        object,
+        definition.and_then(CaptureDefinitionReference::definition_id),
+    );
+    object.push_str(",\"knowledge_definition_version\":");
+    match definition.and_then(CaptureDefinitionReference::definition_version) {
+        Some(version) => object.push_str(&version.to_string()),
+        None => object.push_str("null"),
+    }
+    object.push_str(",\"knowledge_confidence\":");
+    push_option_string(
+        object,
+        definition.and_then(CaptureDefinitionReference::confidence),
+    );
+    object.push_str(",\"knowledge_hardware_validation\":");
+    push_option_string(
+        object,
+        definition.and_then(CaptureDefinitionReference::hardware_validation),
+    );
+    object.push_str(",\"local_ecu_id\":");
+    push_option_string(
+        object,
+        definition.and_then(CaptureDefinitionReference::local_ecu_id),
+    );
+}
+
 fn push_string(object: &mut String, value: &str) {
     object.push('"');
     for character in value.chars() {
@@ -623,6 +668,7 @@ pub fn read(path: &Path) -> Result<ParsedCapture, String> {
     let mut events = Vec::new();
     let mut expected_sequence = 0_u64;
     let mut last_response_offset_us = None;
+    let mut has_knowledge_context = false;
     let mut stopped = false;
     for (line_number, line) in lines.enumerate() {
         let line_number = line_number + 2;
@@ -641,6 +687,14 @@ pub fn read(path: &Path) -> Result<ParsedCapture, String> {
             .checked_add(1)
             .ok_or_else(|| format!("line {line_number}: sequence exhausted"))?;
         let event = parse_event(&object, line_number)?;
+        if matches!(event, CaptureEvent::KnowledgeContext { .. }) {
+            if has_knowledge_context {
+                return Err(format!(
+                    "line {line_number}: duplicate knowledge_context event"
+                ));
+            }
+            has_knowledge_context = true;
+        }
         if let CaptureEvent::ResponsesObserved {
             offset_us: Some(offset_us),
             ..
@@ -712,6 +766,37 @@ fn parse_event(object: &Object, line_number: usize) -> Result<CaptureEvent, Stri
                 wallclock_ms: optional_u64_field(object, "wallclock_ms", line_number)?,
                 profile: optional_string_field(object, "profile", line_number)?,
             })
+        }
+        "knowledge_context" => {
+            fields_exact(
+                object,
+                &[
+                    "schema",
+                    "version",
+                    "type",
+                    "sequence",
+                    "core_version",
+                    "core_commit",
+                    "knowledge_repository",
+                    "knowledge_revision",
+                    "knowledge_schema_version",
+                ],
+                line_number,
+            )?;
+            Ok(CaptureEvent::knowledge_context(
+                CaptureKnowledgeContext::new(
+                    string_field(object, "core_version", line_number)?,
+                    optional_string_field(object, "core_commit", line_number)?,
+                    string_field(object, "knowledge_repository", line_number)?,
+                    string_field(object, "knowledge_revision", line_number)?,
+                    u64_field(object, "knowledge_schema_version", line_number)?
+                        .try_into()
+                        .map_err(|_| {
+                            format!("line {line_number}: knowledge schema version is out of range")
+                        })?,
+                )
+                .map_err(|error| format!("line {line_number}: {error}"))?,
+            ))
         }
         "session_initialized" => {
             fields_exact(
@@ -868,27 +953,55 @@ fn parse_event(object: &Object, line_number: usize) -> Result<CaptureEvent, Stri
             .map_err(|error| format!("line {line_number}: {error}"))
         }
         "read_succeeded" => {
+            let has_definition = object.contains_key("knowledge_definition_id");
             fields_exact(
                 object,
-                &[
-                    "schema",
-                    "version",
-                    "type",
-                    "sequence",
-                    "semantic",
-                    "requested_interval_us",
-                    "due_us",
-                    "started_us",
-                    "finished_us",
-                    "request_payload",
-                    "response_payload",
-                    "value",
-                    "unit",
-                    "source",
-                    "profile",
-                    "decoder",
-                    "provenance",
-                ],
+                if has_definition {
+                    &[
+                        "schema",
+                        "version",
+                        "type",
+                        "sequence",
+                        "semantic",
+                        "requested_interval_us",
+                        "due_us",
+                        "started_us",
+                        "finished_us",
+                        "request_payload",
+                        "response_payload",
+                        "value",
+                        "unit",
+                        "source",
+                        "profile",
+                        "decoder",
+                        "provenance",
+                        "knowledge_definition_id",
+                        "knowledge_definition_version",
+                        "knowledge_confidence",
+                        "knowledge_hardware_validation",
+                        "local_ecu_id",
+                    ]
+                } else {
+                    &[
+                        "schema",
+                        "version",
+                        "type",
+                        "sequence",
+                        "semantic",
+                        "requested_interval_us",
+                        "due_us",
+                        "started_us",
+                        "finished_us",
+                        "request_payload",
+                        "response_payload",
+                        "value",
+                        "unit",
+                        "source",
+                        "profile",
+                        "decoder",
+                        "provenance",
+                    ]
+                },
                 line_number,
             )?;
             let due_us = u64_field(object, "due_us", line_number)?;
@@ -897,6 +1010,44 @@ fn parse_event(object: &Object, line_number: usize) -> Result<CaptureEvent, Stri
             if !(due_us <= started_us && started_us <= finished_us) {
                 return Err(format!("line {line_number}: non-monotonic read timing"));
             }
+            let definition = if has_definition {
+                let definition_id =
+                    optional_string_field(object, "knowledge_definition_id", line_number)?;
+                let definition_version =
+                    optional_u64_field(object, "knowledge_definition_version", line_number)?
+                        .map(|version| {
+                            version.try_into().map_err(|_| {
+                        format!("line {line_number}: knowledge definition version is out of range")
+                    })
+                        })
+                        .transpose()?;
+                let confidence =
+                    optional_string_field(object, "knowledge_confidence", line_number)?;
+                let hardware_validation =
+                    optional_string_field(object, "knowledge_hardware_validation", line_number)?;
+                let local_ecu_id = optional_string_field(object, "local_ecu_id", line_number)?;
+                if definition_id.is_none()
+                    && definition_version.is_none()
+                    && confidence.is_none()
+                    && hardware_validation.is_none()
+                    && local_ecu_id.is_none()
+                {
+                    None
+                } else {
+                    Some(Box::new(
+                        CaptureDefinitionReference::new(
+                            definition_id,
+                            definition_version,
+                            confidence,
+                            hardware_validation,
+                            local_ecu_id,
+                        )
+                        .map_err(|error| format!("line {line_number}: {error}"))?,
+                    ))
+                }
+            } else {
+                None
+            };
             Ok(CaptureEvent::ReadSucceeded {
                 semantic: string_field(object, "semantic", line_number)?,
                 requested_interval_us: u64_field(object, "requested_interval_us", line_number)?,
@@ -920,6 +1071,7 @@ fn parse_event(object: &Object, line_number: usize) -> Result<CaptureEvent, Stri
                 profile: string_field(object, "profile", line_number)?,
                 decoder: string_field(object, "decoder", line_number)?,
                 provenance: string_field(object, "provenance", line_number)?,
+                definition,
             })
         }
         "read_failed" => {
@@ -1969,7 +2121,10 @@ impl<'a> Parser<'a> {
 mod tests {
     use super::*;
     use crate::{
-        capture_events::{CaptureEvent, DiagnosticJobStepStatus, SubscriptionFilterOutcome},
+        capture_events::{
+            CaptureDefinitionReference, CaptureEvent, CaptureKnowledgeContext,
+            DiagnosticJobStepStatus, SubscriptionFilterOutcome,
+        },
         runtime_reducer::RuntimeEvent,
         runtime_state::RuntimeState,
     };
@@ -2002,6 +2157,16 @@ mod tests {
         );
         vec![
             CaptureEvent::capture_started(Some(1_700_000_000_000), Some("engine-baseline".into())),
+            CaptureEvent::knowledge_context(
+                CaptureKnowledgeContext::new(
+                    "0.1.0",
+                    None,
+                    "frankherchet/obdentic-knowledge",
+                    "0123456789abcdef0123456789abcdef01234567",
+                    2,
+                )
+                .unwrap(),
+            ),
             CaptureEvent::SessionInitialized,
             CaptureEvent::runtime_state_changed(from, to, RuntimeEvent::InitializationCompleted),
             CaptureEvent::subscription_configured(
@@ -2047,6 +2212,16 @@ mod tests {
                 profile: "obd2-v1".into(),
                 decoder: "((A * 256) + B) / 4".into(),
                 provenance: "SAE J1979 Mode 01 PID 0C".into(),
+                definition: Some(Box::new(
+                    CaptureDefinitionReference::new(
+                        Some("obd2.engine.rpm".into()),
+                        Some(1),
+                        Some("high".into()),
+                        Some("validated".into()),
+                        Some("local-engine".into()),
+                    )
+                    .unwrap(),
+                )),
             },
             CaptureEvent::ReadFailed {
                 semantic: "engine.rpm".into(),
@@ -2086,6 +2261,27 @@ mod tests {
                 .collect::<Vec<_>>(),
             (0..expected.len() as u64).collect::<Vec<_>>()
         );
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn legacy_capture_without_knowledge_context_or_definition_fields_remains_readable() {
+        let path = temp_path("legacy-knowledge");
+        fs::write(
+            &path,
+            concat!(
+                "{\"schema\":\"OBDENTIC-CAPTURE\",\"version\":1,\"type\":\"header\"}\n",
+                "{\"schema\":\"OBDENTIC-CAPTURE\",\"version\":1,\"type\":\"capture_started\",\"sequence\":0,\"wallclock_ms\":null,\"profile\":null}\n",
+                "{\"schema\":\"OBDENTIC-CAPTURE\",\"version\":1,\"type\":\"session_stopped\",\"sequence\":1,\"offset_us\":0}\n"
+            ),
+        )
+        .unwrap();
+        let parsed = read(&path).unwrap();
+        assert!(parsed
+            .events
+            .iter()
+            .all(|event| !matches!(event, CaptureEvent::KnowledgeContext { .. })));
+        assert_eq!(parsed.status, CaptureStatus::Complete);
         fs::remove_file(path).unwrap();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,6 +342,7 @@ async fn run() -> Result<(), String> {
                         Ok(scheduler) => scheduler,
                         Err(error) => {
                             if let Some(sender) = recorder.as_ref() {
+                                record_capture_start_failure(sender, "tui.live", &error).await?;
                                 apply_runtime_event(
                                     &runtime,
                                     &mut runtime_state,
@@ -1060,11 +1061,7 @@ async fn run_diagnose_dtc_scan(
     let sender = recorder.as_ref().map(jsonl_capture::JsonlRecorder::sender);
     let result = async {
         if sender.is_some() {
-            emit_capture_event(
-                sender,
-                CaptureEvent::capture_started(Some(wallclock_ms()?), Some("dtc.scan".into())),
-            )
-            .await?;
+            emit_capture_started(sender, Some("dtc.scan".into())).await?;
             apply_runtime_event(
                 runtime,
                 state,
@@ -1382,11 +1379,7 @@ async fn run_ea189_dpf_capture(
     let sender = recorder.as_ref().map(jsonl_capture::JsonlRecorder::sender);
     let result = async {
         if sender.is_some() {
-            emit_capture_event(
-                sender,
-                CaptureEvent::capture_started(Some(wallclock_ms()?), Some(profile.into())),
-            )
-            .await?;
+            emit_capture_started(sender, Some(profile.into())).await?;
             apply_runtime_event(
                 runtime,
                 state,
@@ -2338,6 +2331,22 @@ async fn emit_capture_event(
     Ok(())
 }
 
+async fn emit_capture_started(
+    recorder: Option<&jsonl_capture::Sender>,
+    profile: Option<String>,
+) -> Result<(), String> {
+    let Some(recorder) = recorder else {
+        return Ok(());
+    };
+    let context = obdentic::capture_events::CaptureKnowledgeContext::current()?;
+    emit_capture_event(
+        Some(recorder),
+        CaptureEvent::capture_started(Some(wallclock_ms()?), profile),
+    )
+    .await?;
+    emit_capture_event(Some(recorder), CaptureEvent::knowledge_context(context)).await
+}
+
 async fn record_capture_start_failure(
     sender: &jsonl_capture::Sender,
     profile: &str,
@@ -2349,8 +2358,10 @@ async fn record_capture_start_failure(
         .as_millis()
         .try_into()
         .map_err(|_| "wall clock timestamp exceeds supported range")?;
+    let context = obdentic::capture_events::CaptureKnowledgeContext::current()?;
     for event in [
         CaptureEvent::capture_started(Some(wallclock_ms), Some(profile.into())),
+        CaptureEvent::knowledge_context(context),
         CaptureEvent::session_error(error),
         CaptureEvent::SessionStopped { offset_us: 0 },
     ] {
@@ -2977,7 +2988,7 @@ mod tests {
 
     #[tokio::test]
     async fn startup_failure_is_preserved_in_the_capture_event_stream() {
-        let (sender, mut receiver) = tokio::sync::mpsc::channel(3);
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(4);
         record_capture_start_failure(&sender, "engine-baseline", "Carly setup timed out")
             .await
             .unwrap();
@@ -2988,6 +2999,10 @@ mod tests {
                 profile: Some(profile),
                 ..
             }) if profile == "engine-baseline"
+        ));
+        assert!(matches!(
+            receiver.recv().await,
+            Some(CaptureEvent::KnowledgeContext { .. })
         ));
         assert_eq!(
             receiver.recv().await,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -3,7 +3,8 @@ use crate::{
     ble::{is_session_unhealthy, start_session, ReadOutcome, ResponseObservation, SessionClient},
     capability::HardwareCapability,
     capture_events::{
-        CaptureEvent, CaptureSubscription, CaptureTimeUs, ReadTiming, SubscriptionFilterOutcome,
+        CaptureEvent, CaptureKnowledgeContext, CaptureSubscription, CaptureTimeUs, ReadTiming,
+        SubscriptionFilterOutcome,
     },
     prepare_read,
     runtime_actor::RuntimeClient,
@@ -212,6 +213,10 @@ impl TelemetryScheduler {
             .into_iter()
             .map(Into::into)
             .collect::<Vec<_>>();
+        let knowledge_context = recorder
+            .as_ref()
+            .map(|_| CaptureKnowledgeContext::current())
+            .transpose()?;
         let mut runtime_state = runtime
             .snapshot()
             .await
@@ -334,6 +339,7 @@ impl TelemetryScheduler {
             };
         }
         let mut events = std::iter::once(started)
+            .chain(knowledge_context.map(CaptureEvent::knowledge_context))
             .chain(std::iter::once(CaptureEvent::SessionInitialized))
             .chain(configured.into_iter().map(CaptureSubscription::into_event))
             .chain(discovery.into_iter().map(|page| {


### PR DESCRIPTION
Closes #89

- Record the pinned Knowledge repository revision and schema once per JSONL capture.
- Preserve optional resolved definition provenance per decoded fact without inventing definitions for built-in Mode 01 signals.
- Keep historical interpretation separate from current raw-response replay decoding.
- Retain legacy-capture support and expose provenance in capture inspection.

No vehicle-specific capture or evidence data is included.

Local checks: fmt, focused capture tests, scheduler tests, binary tests, clippy -D warnings, build. Full locked tests remain blocked by the pre-existing local knowledge submodule revision mismatch (14 unrelated ECU-identification tests).